### PR TITLE
Fix a clippy warning

### DIFF
--- a/src/pg/mod.rs
+++ b/src/pg/mod.rs
@@ -396,7 +396,7 @@ impl AsyncPgConnection {
                     }
                 } else {
                     // bubble up any error as soon as we have done all lookups
-                    let _ = res?;
+                    res?;
                     break;
                 }
             }


### PR DESCRIPTION
This PR fixes a small clippy warning that was appearing in the CI. Basically, since the result is a unit structure, it doesn't make sense to bind it, even if it's to a discarded binding.