### PR TITLE
Re-add Public Export of Transaction Manager

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ pub use self::mysql::AsyncMysqlConnection;
 pub use self::pg::AsyncPgConnection;
 pub use self::run_query_dsl::*;
 
-use self::transaction_manager::{AnsiTransactionManager, TransactionManager};
+pub use self::transaction_manager::{AnsiTransactionManager, TransactionManager};
 
 /// Perform simple operations on a backend.
 ///


### PR DESCRIPTION
Not sure if this is wanted, or if this change was originally intentional, but this re-exports the transaction manager, since the transaction manager type is required to implement `AsyncConnection`.  As far as I can tell, it is [available in diesel-rs/diesel][available], but implementation is [gated behind a feature][gated] (as of 2.0.0, 2.0.0-rc1 does not have it gated); however, [a trait that is similarly gated][gated-trait] is [not gated in this repository][async-gated-trait].  If this is unwanted, please close.

[available]: https://github.com/diesel-rs/diesel/blob/master/diesel/src/connection/mod.rs#L18
[gated]: https://github.com/diesel-rs/diesel/blob/master/diesel/src/connection/transaction_manager.rs#L41-L43
[gated-trait]: https://github.com/diesel-rs/diesel/blob/v2.0.0-rc1/diesel/src/connection/mod.rs#L23-L26
[async-gated-trait]: https://github.com/weiznich/diesel_async/blob/main/src/lib.rs#L105