### PR TITLE
Fix #26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,9 +117,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
-version = "0.22.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
@@ -513,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "funty"
-version = "1.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -928,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "mysql_async"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14bbbf716bc1db7b86157c4dc6936769efb666318bc1b7b7b046e4c53016e7ef"
+checksum = "456207bb9636a0fdade67a64cea7bdebe6730c3c16ee5e34f2c481838ee5a39e"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -953,17 +953,16 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.6.10",
+ "tokio-util",
  "twox-hash",
  "url",
- "uuid",
 ]
 
 [[package]]
 name = "mysql_common"
-version = "0.28.2"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4140827f2d12750de1e8755442577e4292a835f26ff2f659f0a380d1d71020b0"
+checksum = "522f2f30f72de409fc04f88df25a031f98cfc5c398a94e0b892cabb33a1464cb"
 dependencies = [
  "base64",
  "bigdecimal",
@@ -1309,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "radium"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1708,21 +1707,7 @@ dependencies = [
  "postgres-types",
  "socket2",
  "tokio",
- "tokio-util 0.7.3",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1811,12 +1796,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom",
-]
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 
 [[package]]
 name = "vcpkg"
@@ -1963,9 +1945,9 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "wyz"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
 dependencies = [
  "tap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,24 +17,24 @@ diesel = { version = "2.0.0", default-features = false, features = ["i-implement
 async-trait = "0.1.51"
 futures = "0.3.17"
 tokio-postgres = { version = "0.7.2", optional = true}
-tokio = { version = "1.12.0", features = ["rt"], optional = true}
-mysql_async = { version = "0.29.0", optional = true}
-mysql_common = {version = "0.28.0", optional = true}
+tokio = { version = "1", optional = true}
+mysql_async = { version = "0.30.0", optional = true}
+mysql_common = {version = "0.29.0", optional = true}
 
 bb8 = {version = "0.8", optional = true}
 deadpool = {version = "0.9", optional = true}
 mobc = {version = "0.7", optional = true}
 
 [dev-dependencies]
-tokio = {version = "1.12.0", features = ["rt", "macros"]}
+tokio = {version = "1.12.0", features = ["rt", "macros", "rt-multi-thread"]}
 cfg-if = "1"
 chrono = "0.4"
-diesel = { version = "2.0.0-rc.1", default-features = false,  features = ["chrono"]}
+diesel = { version = "2.0.0", default-features = false,  features = ["chrono"]}
 
 [features]
 default = []
 mysql = ["diesel/mysql_backend", "mysql_async", "mysql_common"]
-postgres = ["diesel/postgres_backend", "tokio-postgres", "tokio", "tokio/rt-multi-thread"]
+postgres = ["diesel/postgres_backend", "tokio-postgres", "tokio"]
 
 [[test]]
 name = "integration_tests"

--- a/src/doctest_setup.rs
+++ b/src/doctest_setup.rs
@@ -106,31 +106,31 @@ cfg_if::cfg_if! {
         }
 
         async fn create_tables(connection: &mut AsyncMysqlConnection) {
-               diesel::sql_query("CREATE TABLE IF NOT EXISTS users (
+               diesel::sql_query("CREATE TEMPORARY TABLE IF NOT EXISTS users (
                 id INTEGER PRIMARY KEY AUTO_INCREMENT,
                 name TEXT NOT NULL
             ) CHARACTER SET utf8mb4").execute(connection).await.unwrap();
 
 
-            diesel::sql_query("CREATE TABLE IF NOT EXISTS animals (
+            diesel::sql_query("CREATE TEMPORARY TABLE IF NOT EXISTS animals (
                 id INTEGER PRIMARY KEY AUTO_INCREMENT,
                 species TEXT NOT NULL,
                 legs INTEGER NOT NULL,
                 name TEXT
             ) CHARACTER SET utf8mb4").execute(connection).await.unwrap();
 
-            diesel::sql_query("CREATE TABLE IF NOT EXISTS posts (
+            diesel::sql_query("CREATE TEMPORARY TABLE IF NOT EXISTS posts (
                 id INTEGER PRIMARY KEY AUTO_INCREMENT,
                 user_id INTEGER NOT NULL,
                 title TEXT NOT NULL
             ) CHARACTER SET utf8mb4").execute(connection).await.unwrap();
 
-            diesel::sql_query("CREATE TABLE IF NOT EXISTS comments (
+            diesel::sql_query("CREATE TEMPORARY TABLE IF NOT EXISTS comments (
                 id INTEGER PRIMARY KEY AUTO_INCREMENT,
                 post_id INTEGER NOT NULL,
                 body TEXT NOT NULL
             ) CHARACTER SET utf8mb4").execute(connection).await.unwrap();
-            diesel::sql_query("CREATE TABLE IF NOT EXISTS brands (
+            diesel::sql_query("CREATE TEMPORARY TABLE IF NOT EXISTS brands (
                 id INTEGER PRIMARY KEY AUTO_INCREMENT,
                 color VARCHAR(255) NOT NULL DEFAULT 'Green',
                 accent VARCHAR(255) DEFAULT 'Blue'


### PR DESCRIPTION
`mysql_async` requires us to explicitly close prepared statements if
their statement cache is disabled. This commit introduces the necessary
code to close any non-cached prepared statements. Any cached prepared
statement will live as long as the connection itself. They will be
automatically deallocated on connection close on server side (as the the
corresponding connection is gone at this point).