### PR TITLE
Fix the type alias for deadpool's `BuildError`

### DIFF
--- a/src/pooled_connection/deadpool.rs
+++ b/src/pooled_connection/deadpool.rs
@@ -47,7 +47,7 @@ pub type Pool<C> = deadpool::managed::Pool<AsyncDieselConnectionManager<C>>;
 /// Type alias for using [`deadpool::managed::PoolBuilder`] with [`diesel-async`]
 pub type PoolBuilder<C> = deadpool::managed::PoolBuilder<AsyncDieselConnectionManager<C>>;
 /// Type alias for using [`deadpool::managed::BuildError`] with [`diesel-async`]
-pub type BuildError = deadpool::managed::BuildError<PoolError>;
+pub type BuildError = deadpool::managed::BuildError<super::PoolError>;
 /// Type alias for using [`deadpool::managed::PoolError`] with [`diesel-async`]
 pub type PoolError = deadpool::managed::PoolError<super::PoolError>;
 /// Type alias for using [`deadpool::managed::Object`] with [`diesel-async`]


### PR DESCRIPTION
If I understand it correctly, `diesel_async::pooled_connection::deadpool::BuildError` is the error returned when
`deadpool::managed::PoolBuilder::build` failed. 
According to the [docs](https://docs.rs/deadpool/0.9.5/deadpool/managed/struct.PoolBuilder.html), the error should be `BuildError<M::Error>` where M is `AsyncDieselConnectionManager`, so the error should be
`deadpool::managed::BuildError<<AsyncDieselConnectionManager as deadpool::managed::Manager>::Error>` which is 

`deadpool::managed::BuildError<diesel_async::pooled_connection::PoolError>`, 

but in the current code, it is an alias of 

`deadpool::managed::BuildError<deadpool::managed::PoolError<diesel_async::pooled_connection::PoolError>>`