### PR TITLE
Add rudimentary TLS support for postgresql

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "diesel-async"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "bb8",
@@ -369,6 +369,8 @@ dependencies = [
  "mobc",
  "mysql_async",
  "mysql_common",
+ "native-tls",
+ "postgres-native-tls",
  "tokio",
  "tokio-postgres",
 ]
@@ -1224,6 +1226,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
+name = "postgres-native-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d442770e2b1e244bb5eb03b31c79b65bb2568f413b899eaba850fa945a65954"
+dependencies = [
+ "futures",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-postgres",
+]
+
+[[package]]
 name = "postgres-protocol"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1662,7 +1677,19 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ description = "An async extension for Diesel the safe, extensible ORM and Query 
 diesel = { version = "2.0.0", default-features = false, features = ["i-implement-a-third-party-backend-and-opt-into-breaking-changes"]}
 async-trait = "0.1.51"
 futures = "0.3.17"
+native-tls = { version = "0.2", optional = true}
+postgres-native-tls = { version = "0.5", optional = true}
 tokio-postgres = { version = "0.7.2", optional = true}
 tokio = { version = "1", optional = true}
 mysql_async = { version = "0.30.0", optional = true}
@@ -34,7 +36,7 @@ diesel = { version = "2.0.0", default-features = false,  features = ["chrono"]}
 [features]
 default = []
 mysql = ["diesel/mysql_backend", "mysql_async", "mysql_common"]
-postgres = ["diesel/postgres_backend", "tokio-postgres", "tokio", "tokio/rt"]
+postgres = ["diesel/postgres_backend", "native-tls", "postgres-native-tls", "tokio-postgres", "tokio", "tokio/rt"]
 
 [[test]]
 name = "integration_tests"


### PR DESCRIPTION
Adds a postgresql-native-tls dependency and uses it by default. This brings the postgresql inline with mysql_async which also depends on native_tls.

---

I am not sure if this is the best way to implement this feature, I can re-work it to be behind a feature flag if required.