### PR TITLE
Re-export of TransactionManagerStatus

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,9 @@ pub use self::pg::AsyncPgConnection;
 pub use self::run_query_dsl::*;
 
 #[doc(inline)]
-pub use self::transaction_manager::{AnsiTransactionManager, TransactionManager};
+pub use self::transaction_manager::{
+    AnsiTransactionManager, TransactionManager, TransactionManagerStatus,
+};
 
 /// Perform simple operations on a backend.
 ///


### PR DESCRIPTION
Not sure if this is intended, but `TransactionManagerStatus` is effectively hidden from public access; however, this enum is required if you want to implement the trait `TransactionManager`, as the trait function `TransactionManager::transaction_manager_status_mut` returns a `TransactionManagerStatus` directly.  As far as I can tell, it is accessible in [diesel], even if gated behind a feature.

[diesel]: https://github.com/diesel-rs/diesel/blob/master/diesel/src/connection/mod.rs#L18