### PR TITLE
Add fmt::Debug impls to AsyncDieselConnectionManager and AsyncPgConnection

### DIFF
--- a/src/pg/mod.rs
+++ b/src/pg/mod.rs
@@ -103,7 +103,7 @@ pub struct AsyncPgConnection {
 
 impl std::fmt::Debug for AsyncPgConnection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("AsyncPgConnection").finish()
+        f.debug_struct("AsyncPgConnection").finish_non_exhaustive()
     }
 }
 

--- a/src/pg/mod.rs
+++ b/src/pg/mod.rs
@@ -101,6 +101,12 @@ pub struct AsyncPgConnection {
     metadata_cache: Arc<Mutex<Option<PgMetadataCache>>>,
 }
 
+impl std::fmt::Debug for AsyncPgConnection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AsyncPgConnection").finish()
+    }
+}
+
 #[async_trait::async_trait]
 impl SimpleAsyncConnection for AsyncPgConnection {
     async fn batch_execute(&mut self, query: &str) -> QueryResult<()> {

--- a/src/pooled_connection/mod.rs
+++ b/src/pooled_connection/mod.rs
@@ -50,6 +50,14 @@ pub struct AsyncDieselConnectionManager<C> {
     connection_url: String,
 }
 
+impl<C> std::fmt::Debug for AsyncDieselConnectionManager<C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AsyncDieselConnectionManager")
+            .field("connection_url", &self.connection_url)
+            .finish()
+    }
+}
+
 impl<C> AsyncDieselConnectionManager<C> {
     /// Returns a new connection manager,
     /// which establishes connections to the given database URL.

--- a/src/pooled_connection/mod.rs
+++ b/src/pooled_connection/mod.rs
@@ -53,8 +53,7 @@ pub struct AsyncDieselConnectionManager<C> {
 impl<C> std::fmt::Debug for AsyncDieselConnectionManager<C> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AsyncDieselConnectionManager")
-            .field("connection_url", &self.connection_url)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
First, thank you for this crate and also the latest changes (`new_with_setup`), which enabled me to use it with rustls.

-----

This change is needed to use the `#[instrument]` macro of [tracing](https://crates.io/crates/tracing), which seems to require Debug impls for types being part of the function; since they get printed as part of the logs.

Example:
https://github.com/asaaki/capture-the-ip/blob/main/cti_core/src/app/api.rs#L95-L97

The state is a pool represented by the above mentioned types.
The tracing crate is very unhappy if those types are not Debug.

I kept the implementations very simple and minimal;
the connection would only display its name, the manager also includes the connection URL. All other fields left untouched to not infect everything.