### PR TITLE
postgres: add cancel_token

### DIFF
--- a/src/pg/mod.rs
+++ b/src/pg/mod.rs
@@ -296,6 +296,11 @@ impl AsyncPgConnection {
         Ok(conn)
     }
 
+    /// Constructs a cancellation token that can later be used to request cancellation of a query running on the connection associated with this client.
+    pub fn cancel_token(&self) -> tokio_postgres::CancelToken {
+        self.conn.cancel_token()
+    }
+
     async fn set_config_options(&mut self) -> QueryResult<()> {
         use crate::run_query_dsl::RunQueryDsl;
 


### PR DESCRIPTION
This PR adds the ability to cancel postgres queries from `AsyncPgConnection`.

https://github.com/weiznich/diesel_async/discussions/57