### PR TITLE
Adding test transaction to the trait AsyncConnection

### DIFF
--- a/src/pg/mod.rs
+++ b/src/pg/mod.rs
@@ -123,7 +123,7 @@ impl AsyncConnection for AsyncPgConnection {
             .map_err(ErrorHelper)?;
         tokio::spawn(async move {
             if let Err(e) = connection.await {
-                eprintln!("connection error: {}", e);
+                eprintln!("connection error: {e}");
             }
         });
         Self::try_from(client).await

--- a/src/pooled_connection/mod.rs
+++ b/src/pooled_connection/mod.rs
@@ -39,6 +39,9 @@ impl fmt::Display for PoolError {
 
 impl std::error::Error for PoolError {}
 
+type SetupCallback<C> =
+    Box<dyn Fn(&str) -> future::BoxFuture<diesel::ConnectionResult<C>> + Send + Sync>;
+
 /// An connection manager for use with diesel-async.
 ///
 /// See the concrete pool implementations for examples:
@@ -46,7 +49,7 @@ impl std::error::Error for PoolError {}
 /// * [bb8](self::bb8)
 /// * [mobc](self::mobc)
 pub struct AsyncDieselConnectionManager<C> {
-    setup: Box<dyn Fn(&str) -> future::BoxFuture<diesel::ConnectionResult<C>> + Send + Sync>,
+    setup: SetupCallback<C>,
     connection_url: String,
 }
 

--- a/src/transaction_manager.rs
+++ b/src/transaction_manager.rs
@@ -292,7 +292,7 @@ where
         let start_transaction_sql = match transaction_state.transaction_depth() {
             None => Cow::from("BEGIN"),
             Some(transaction_depth) => {
-                Cow::from(format!("SAVEPOINT diesel_savepoint_{}", transaction_depth))
+                Cow::from(format!("SAVEPOINT diesel_savepoint_{transaction_depth}"))
             }
         };
         conn.batch_execute(&start_transaction_sql).await?;

--- a/tests/type_check.rs
+++ b/tests/type_check.rs
@@ -161,8 +161,8 @@ async fn test_timestamp() {
     type_check::<_, sql_types::Timestamp>(
         conn,
         chrono::NaiveDateTime::new(
-            chrono::NaiveDate::from_ymd(2021, 09, 27),
-            chrono::NaiveTime::from_hms_milli(17, 44, 23, 0),
+            chrono::NaiveDate::from_ymd_opt(2021, 09, 27).unwrap(),
+            chrono::NaiveTime::from_hms_milli_opt(17, 44, 23, 0).unwrap(),
         ),
     )
     .await;
@@ -171,13 +171,18 @@ async fn test_timestamp() {
 #[tokio::test]
 async fn test_date() {
     let conn = &mut connection().await;
-    type_check::<_, sql_types::Date>(conn, chrono::NaiveDate::from_ymd(2021, 09, 27)).await;
+    type_check::<_, sql_types::Date>(conn, chrono::NaiveDate::from_ymd_opt(2021, 09, 27).unwrap())
+        .await;
 }
 
 #[tokio::test]
 async fn test_time() {
     let conn = &mut connection().await;
-    type_check::<_, sql_types::Time>(conn, chrono::NaiveTime::from_hms_milli(17, 44, 23, 0)).await;
+    type_check::<_, sql_types::Time>(
+        conn,
+        chrono::NaiveTime::from_hms_milli_opt(17, 44, 23, 0).unwrap(),
+    )
+    .await;
 }
 
 #[cfg(feature = "mysql")]
@@ -187,8 +192,8 @@ async fn test_datetime() {
     type_check::<_, sql_types::Datetime>(
         conn,
         chrono::NaiveDateTime::new(
-            chrono::NaiveDate::from_ymd(2021, 09, 30),
-            chrono::NaiveTime::from_hms_milli(12, 06, 42, 0),
+            chrono::NaiveDate::from_ymd_opt(2021, 09, 30).unwrap(),
+            chrono::NaiveTime::from_hms_milli_opt(12, 06, 42, 0).unwrap(),
         ),
     )
     .await;


### PR DESCRIPTION
This will be adding the test_transaction function to the AsyncConnection in a similar manner as is implemented under the current Diesel implementation