### PR TITLE
Fix deadpool example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ use diesel_async::RunQueryDsl;
 
 // create a new connection pool with the default config
 let config = AsyncDieselConnectionManager::<diesel_async::AsyncPgConnection>::new(std::env::var("DATABASE_URL")?);
-let pool = Pool::builder().build(config)?;
+let pool = Pool::builder(config).build()?;
 
 // checkout a connection from the pool
 let mut conn = pool.get().await?;


### PR DESCRIPTION
While setting up diesel async in axum I noticed that the README had a tiny error. Looking at the docs of deadpool the `Pool::builder(..)` accepts the `manager` as the first argument (instead of the `build()` method).