### PR TITLE
Implement `MigrationConnection` for the `AsyncConnectionWrapper` type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tokio = {version = "1.12.0", features = ["rt", "macros", "rt-multi-thread"]}
 cfg-if = "1"
 chrono = "0.4"
 diesel = { version = "2.1.0", default-features = false,  features = ["chrono"]}
+diesel_migrations = "2.1.0"
 
 [features]
 default = []

--- a/src/async_connection_wrapper.rs
+++ b/src/async_connection_wrapper.rs
@@ -100,6 +100,8 @@ pub type AsyncConnectionWrapper<C, B = self::implementation::Tokio> =
 pub use self::implementation::AsyncConnectionWrapper;
 
 mod implementation {
+    use diesel::connection::SimpleConnection;
+
     use super::*;
 
     pub struct AsyncConnectionWrapper<C, B> {
@@ -268,6 +270,17 @@ mod implementation {
             <C::TransactionManager as crate::TransactionManager<_>>::is_broken_transaction_manager(
                 &mut self.inner,
             )
+        }
+    }
+
+    impl<C, B> diesel::migration::MigrationConnection for AsyncConnectionWrapper<C, B>
+    where
+        B: BlockOn,
+        Self: diesel::Connection,
+    {
+        fn setup(&mut self) -> diesel::QueryResult<usize> {
+            self.batch_execute(diesel::migration::CREATE_MIGRATIONS_TABLE)
+                .map(|()| 0)
         }
     }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -92,6 +92,9 @@ type TestConnection = AsyncMysqlConnection;
 #[cfg(feature = "postgres")]
 type TestConnection = AsyncPgConnection;
 
+#[allow(dead_code)]
+type TestBackend = <TestConnection as AsyncConnection>::Backend;
+
 #[tokio::test]
 async fn test_basic_insert_and_load() -> QueryResult<()> {
     let conn = &mut connection().await;

--- a/tests/sync_wrapper.rs
+++ b/tests/sync_wrapper.rs
@@ -1,3 +1,4 @@
+use diesel::migration::Migration;
 use diesel::prelude::*;
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 
@@ -23,4 +24,16 @@ async fn test_sync_wrapper_under_runtime() {
     })
     .await
     .unwrap();
+}
+
+#[test]
+fn check_run_migration() {
+    use diesel_migrations::MigrationHarness;
+
+    let db_url = std::env::var("DATABASE_URL").unwrap();
+    let migrations: Vec<Box<dyn Migration<crate::TestBackend>>> = Vec::new();
+    let mut conn = AsyncConnectionWrapper::<crate::TestConnection>::establish(&db_url).unwrap();
+
+    // just use `run_migrations` here because that's the easiest one without additional setup
+    conn.run_migrations(&migrations).unwrap();
 }


### PR DESCRIPTION
This allows to execute migrations. Also add a simple test for that.