### PR TITLE
fix: avoid where Self: 'a clause on GATs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,21 +127,13 @@ pub trait SimpleAsyncConnection {
 #[async_trait::async_trait]
 pub trait AsyncConnection: SimpleAsyncConnection + Sized + Send {
     /// The future returned by `AsyncConnection::execute`
-    type ExecuteFuture<'conn, 'query>: Future<Output = QueryResult<usize>> + Send
-    where
-        Self: 'conn;
+    type ExecuteFuture<'conn, 'query>: Future<Output = QueryResult<usize>> + Send;
     /// The future returned by `AsyncConnection::load`
-    type LoadFuture<'conn, 'query>: Future<Output = QueryResult<Self::Stream<'conn, 'query>>> + Send
-    where
-        Self: 'conn;
+    type LoadFuture<'conn, 'query>: Future<Output = QueryResult<Self::Stream<'conn, 'query>>> + Send;
     /// The inner stream returned by `AsyncConnection::load`
-    type Stream<'conn, 'query>: Stream<Item = QueryResult<Self::Row<'conn, 'query>>> + Send
-    where
-        Self: 'conn;
+    type Stream<'conn, 'query>: Stream<Item = QueryResult<Self::Row<'conn, 'query>>> + Send;
     /// The row type used by the stream returned by `AsyncConnection::load`
-    type Row<'conn, 'query>: Row<'conn, Self::Backend>
-    where
-        Self: 'conn;
+    type Row<'conn, 'query>: Row<'conn, Self::Backend>;
 
     /// The backend this type connects to
     type Backend: Backend;
@@ -341,4 +333,10 @@ pub trait AsyncConnection: SimpleAsyncConnection + Sized + Send {
     fn transaction_state(
         &mut self,
     ) -> &mut <Self::TransactionManager as TransactionManager<Self>>::TransactionStateData;
+
+    #[doc(hidden)]
+    fn _silence_lint_on_execute_future(_: Self::ExecuteFuture<'_, '_>) {}
+
+    #[doc(hidden)]
+    fn _silence_lint_on_load_future(_: Self::LoadFuture<'_, '_>) {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,9 +334,11 @@ pub trait AsyncConnection: SimpleAsyncConnection + Sized + Send {
         &mut self,
     ) -> &mut <Self::TransactionManager as TransactionManager<Self>>::TransactionStateData;
 
+    // These functions allow the associated types (`ExecuteFuture`, `LoadFuture`, etc.) to
+    // compile without a `where Self: '_` clause. This is needed the because bound causes
+    // lifetime issues when using `transaction()` with generic `AsyncConnection`s.
     #[doc(hidden)]
     fn _silence_lint_on_execute_future(_: Self::ExecuteFuture<'_, '_>) {}
-
     #[doc(hidden)]
     fn _silence_lint_on_load_future(_: Self::LoadFuture<'_, '_>) {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,6 +337,8 @@ pub trait AsyncConnection: SimpleAsyncConnection + Sized + Send {
     // These functions allow the associated types (`ExecuteFuture`, `LoadFuture`, etc.) to
     // compile without a `where Self: '_` clause. This is needed the because bound causes
     // lifetime issues when using `transaction()` with generic `AsyncConnection`s.
+    //
+    // See: https://github.com/rust-lang/rust/issues/87479
     #[doc(hidden)]
     fn _silence_lint_on_execute_future(_: Self::ExecuteFuture<'_, '_>) {}
     #[doc(hidden)]

--- a/src/pooled_connection/mod.rs
+++ b/src/pooled_connection/mod.rs
@@ -181,14 +181,10 @@ where
     C::Target: AsyncConnection,
 {
     type ExecuteFuture<'conn, 'query> =
-        <C::Target as AsyncConnection>::ExecuteFuture<'conn, 'query>
-        where C::Target: 'conn, C: 'conn;
-    type LoadFuture<'conn, 'query> = <C::Target as AsyncConnection>::LoadFuture<'conn, 'query>
-                where C::Target: 'conn, C: 'conn;
-    type Stream<'conn, 'query> = <C::Target as AsyncConnection>::Stream<'conn, 'query>
-                where C::Target: 'conn, C: 'conn;
-    type Row<'conn, 'query> = <C::Target as AsyncConnection>::Row<'conn, 'query>
-                where C::Target: 'conn, C: 'conn;
+        <C::Target as AsyncConnection>::ExecuteFuture<'conn, 'query>;
+    type LoadFuture<'conn, 'query> = <C::Target as AsyncConnection>::LoadFuture<'conn, 'query>;
+    type Stream<'conn, 'query> = <C::Target as AsyncConnection>::Stream<'conn, 'query>;
+    type Row<'conn, 'query> = <C::Target as AsyncConnection>::Row<'conn, 'query>;
 
     type Backend = <C::Target as AsyncConnection>::Backend;
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -13,7 +13,9 @@ mod pooling;
 mod sync_wrapper;
 mod type_check;
 
-async fn transaction_test(conn: &mut TestConnection) -> QueryResult<()> {
+async fn transaction_test<C: AsyncConnection<Backend = TestBackend>>(
+    conn: &mut C,
+) -> QueryResult<()> {
     let res = conn
         .transaction::<i32, diesel::result::Error, _>(|conn| {
             Box::pin(async move {


### PR DESCRIPTION
This removes the `where Self: 'a` clauses on `AsyncConnection`'s associated types. The compiler over-eagerly asserts the trait should have the constraint but it is flawed when handling transactions generically. Dummy `_silence_lint_on_*` functions were added to convince the compiler the constraints are not required.

Fixes: #104 