### PR TITLE
Expose build_transaction through AsyncConnectionWrapper

### DIFF
--- a/src/async_connection_wrapper.rs
+++ b/src/async_connection_wrapper.rs
@@ -200,6 +200,17 @@ mod implementation {
         }
     }
 
+    #[cfg(feature = "postgres")]
+    impl<C, B> crate::pg::BuildTransaction<C> for AsyncConnectionWrapper<C, B>
+    where
+        C: crate::AsyncConnection + crate::pg::BuildTransaction<C>,
+        B: BlockOn + Send,
+    {
+        fn build_transaction(&mut self) -> crate::pg::TransactionBuilder<C> {
+            self.inner.build_transaction()
+        }
+    }
+
     pub struct AsyncCursorWrapper<'a, S, B> {
         stream: Pin<Box<S>>,
         runtime: &'a B,

--- a/src/pg/transaction_builder.rs
+++ b/src/pg/transaction_builder.rs
@@ -380,6 +380,7 @@ impl QueryFragment<Pg> for Deferrable {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pg::BuildTransaction;
 
     #[tokio::test]
     async fn test_transaction_builder_generates_correct_sql() {


### PR DESCRIPTION
This addresses https://github.com/weiznich/diesel_async/issues/115.

I feel I've made the section in async_connection_wrapper more complex than necessary, I can try tidy it up.

The tests don't pass right now but I know the core section compiles.

Let me know what you think about this solution!