### PR TITLE
Don't eprintln in AsyncPgConnection

### DIFF
--- a/src/pg/mod.rs
+++ b/src/pg/mod.rs
@@ -125,9 +125,7 @@ impl AsyncConnection for AsyncPgConnection {
             .await
             .map_err(ErrorHelper)?;
         tokio::spawn(async move {
-            if let Err(e) = connection.await {
-                eprintln!("connection error: {e}");
-            }
+            let _ = connection.await;
         });
         Self::try_from(client).await
     }


### PR DESCRIPTION
## Summary
I'm using this library from a CLI and I'd rather avoid these prints. Sadly there isn't much downstream folks can do about prints inside a library. If the library used `tracing` I'd switch this eprintln to use that instead, but since it doesn't, I just remove it. Let me know what you think!

## Test Plan
```
cargo build --features postgres
```