### PR TITLE
Exporting a PooledConnection type for mobc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,59 +6,60 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## [Unreleased]
 
-- Added type `diesel_async::pooled_connection::mobc::PooledConnection`
+* Added type `diesel_async::pooled_connection::mobc::PooledConnection`
 
 ## [0.4.1] - 2023-09-01
 
-- Fixed feature flags for docs.rs
+* Fixed feature flags for docs.rs
 
 ## [0.4.0] - 2023-09-01
 
-- Add a `AsyncConnectionWrapper` type to turn a `diesel_async::AsyncConnection` into a `diesel::Connection`. This might be used to execute migrations via `diesel_migrations`.
-- Add some connection pool configurations to specify how connections
-  in the pool should be checked if they are still valid
+* Add a `AsyncConnectionWrapper` type to turn a `diesel_async::AsyncConnection` into a `diesel::Connection`. This might be used to execute migrations via `diesel_migrations`. 
+* Add some connection pool configurations to specify how connections
+in the pool should be checked if they are still valid
 
 ## [0.3.2] - 2023-07-24
 
-- Fix `TinyInt` serialization
-- Check for open transactions before returning the connection to the pool
+* Fix `TinyInt` serialization
+* Check for open transactions before returning the connection to the pool
 
 ## [0.3.1] - 2023-06-07
 
-- Minor readme fixes
-- Add a missing `UpdateAndFetchResults` impl
+* Minor readme fixes
+* Add a missing `UpdateAndFetchResults` impl
 
 ## [0.3.0] - 2023-05-26
 
-- Compatibility with diesel 2.1
+* Compatibility with diesel 2.1
 
 ## [0.2.2] - 2023-04-14
 
-- Dependency updates for `mysql-async` to allow newer versions
+* Dependency updates for `mysql-async` to allow newer versions
 
 ## [0.2.1] - 2023-03-08
 
-- Dependency updates for `mobc` and `mysql-async` to allow newer versions as well
-- Extend the README
-- Improve the version constraint for diesel so that we do not end up using a newer
-  diesel version that's incompatible
+* Dependency updates for `mobc` and `mysql-async` to allow newer versions as well 
+* Extend the README
+* Improve the version constraint for diesel so that we do not end up using a newer
+ diesel version that's incompatible
 
 ## [0.2.0] - 2022-12-16
 
-- [#38](https://github.com/weiznich/diesel_async/pull/38) Relax the requirements for borrowed captures in the transaction closure
-- [#41](https://github.com/weiznich/diesel_async/pull/41) Remove GAT workarounds from various traits (Raises the MSRV to 1.65)
-- [#42](https://github.com/weiznich/diesel_async/pull/42) Add an additional `AsyncDieselConnectionManager` constructor that allows to specify a custom connection setup method to allow setting up postgres TLS connections
-- Relicense the crate under the MIT or Apache 2.0 License
+* [#38](https://github.com/weiznich/diesel_async/pull/38) Relax the requirements for borrowed captures in the transaction closure
+* [#41](https://github.com/weiznich/diesel_async/pull/41) Remove GAT workarounds from various traits (Raises the MSRV to 1.65)
+* [#42](https://github.com/weiznich/diesel_async/pull/42) Add an additional `AsyncDieselConnectionManager` constructor that allows to specify a custom connection setup method to allow setting up postgres TLS connections
+* Relicense the crate under the MIT or Apache 2.0 License
 
 ## [0.1.1] - 2022-10-19
 
 ### Fixes
 
-- Fix prepared statement leak for the mysql backend implementation
+* Fix prepared statement leak for the mysql backend implementation
+
 
 ## 0.1.0 - 2022-09-27
 
-- Initial release
+* Initial release
 
 [0.1.1]: https://github.com/weiznich/diesel_async/compare/v0.1.0...v0.1.1
 [0.2.0]: https://github.com/weiznich/diesel_async/compare/v0.1.1...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,62 +4,61 @@ All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
 
-## [0.4.2] - 2023-10-26
+## [Unreleased]
 
-* Added type `diesel_async::pooled_connection::mobc::PooledConnection`
+- Added type `diesel_async::pooled_connection::mobc::PooledConnection`
 
 ## [0.4.1] - 2023-09-01
 
-* Fixed feature flags for docs.rs
+- Fixed feature flags for docs.rs
 
 ## [0.4.0] - 2023-09-01
 
-* Add a `AsyncConnectionWrapper` type to turn a `diesel_async::AsyncConnection` into a `diesel::Connection`. This might be used to execute migrations via `diesel_migrations`. 
-* Add some connection pool configurations to specify how connections
-in the pool should be checked if they are still valid
+- Add a `AsyncConnectionWrapper` type to turn a `diesel_async::AsyncConnection` into a `diesel::Connection`. This might be used to execute migrations via `diesel_migrations`.
+- Add some connection pool configurations to specify how connections
+  in the pool should be checked if they are still valid
 
 ## [0.3.2] - 2023-07-24
 
-* Fix `TinyInt` serialization
-* Check for open transactions before returning the connection to the pool
+- Fix `TinyInt` serialization
+- Check for open transactions before returning the connection to the pool
 
 ## [0.3.1] - 2023-06-07
 
-* Minor readme fixes
-* Add a missing `UpdateAndFetchResults` impl
+- Minor readme fixes
+- Add a missing `UpdateAndFetchResults` impl
 
 ## [0.3.0] - 2023-05-26
 
-* Compatibility with diesel 2.1
+- Compatibility with diesel 2.1
 
 ## [0.2.2] - 2023-04-14
 
-* Dependency updates for `mysql-async` to allow newer versions
+- Dependency updates for `mysql-async` to allow newer versions
 
 ## [0.2.1] - 2023-03-08
 
-* Dependency updates for `mobc` and `mysql-async` to allow newer versions as well 
-* Extend the README
-* Improve the version constraint for diesel so that we do not end up using a newer
- diesel version that's incompatible
+- Dependency updates for `mobc` and `mysql-async` to allow newer versions as well
+- Extend the README
+- Improve the version constraint for diesel so that we do not end up using a newer
+  diesel version that's incompatible
 
 ## [0.2.0] - 2022-12-16
 
-* [#38](https://github.com/weiznich/diesel_async/pull/38) Relax the requirements for borrowed captures in the transaction closure
-* [#41](https://github.com/weiznich/diesel_async/pull/41) Remove GAT workarounds from various traits (Raises the MSRV to 1.65)
-* [#42](https://github.com/weiznich/diesel_async/pull/42) Add an additional `AsyncDieselConnectionManager` constructor that allows to specify a custom connection setup method to allow setting up postgres TLS connections
-* Relicense the crate under the MIT or Apache 2.0 License
+- [#38](https://github.com/weiznich/diesel_async/pull/38) Relax the requirements for borrowed captures in the transaction closure
+- [#41](https://github.com/weiznich/diesel_async/pull/41) Remove GAT workarounds from various traits (Raises the MSRV to 1.65)
+- [#42](https://github.com/weiznich/diesel_async/pull/42) Add an additional `AsyncDieselConnectionManager` constructor that allows to specify a custom connection setup method to allow setting up postgres TLS connections
+- Relicense the crate under the MIT or Apache 2.0 License
 
 ## [0.1.1] - 2022-10-19
 
 ### Fixes
 
-* Fix prepared statement leak for the mysql backend implementation
-
+- Fix prepared statement leak for the mysql backend implementation
 
 ## 0.1.0 - 2022-09-27
 
-* Initial release
+- Initial release
 
 [0.1.1]: https://github.com/weiznich/diesel_async/compare/v0.1.0...v0.1.1
 [0.2.0]: https://github.com/weiznich/diesel_async/compare/v0.1.1...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
 
+## [0.4.2] - 2023-10-26
+
+* Added type `diesel_async::pooled_connection::mobc::PooledConnection`
+
 ## [0.4.1] - 2023-09-01
 
 * Fixed feature flags for docs.rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel-async"
-version = "0.4.2"
+version = "0.4.1"
 authors = ["Georg Semmler <github@weiznich.de>"]
 edition = "2021"
 autotests = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel-async"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Georg Semmler <github@weiznich.de>"]
 edition = "2021"
 autotests = false

--- a/src/pooled_connection/mobc.rs
+++ b/src/pooled_connection/mobc.rs
@@ -46,6 +46,9 @@ use mobc::Manager;
 /// Type alias for using [`mobc::Pool`] with [`diesel-async`]
 pub type Pool<C> = mobc::Pool<AsyncDieselConnectionManager<C>>;
 
+/// Type alias for using [`mobc::Connection`] with [`diesel-async`]
+pub type PooledConnection<C> = mobc::Connection<AsyncDieselConnectionManager<C>>;
+
 /// Type alias for using [`mobc::Builder`] with [`diesel-async`]
 pub type Builder<C> = mobc::Builder<AsyncDieselConnectionManager<C>>;
 


### PR DESCRIPTION
Some projects can avoid specifying `mobc` dependency by reusing this exported type. Also aligns `mobc` module more with its alternatives `deadpool` and `bb8`.