### PR TITLE
Fix #138 (Incoherent UPDATE return for MySQL/MariaDB)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 ## [Unreleased]
 
 * Added type `diesel_async::pooled_connection::mobc::PooledConnection`
+* MySQL/MariaDB now use `CLIENT_FOUND_ROWS` capability to allow consistent behavior with PostgreSQL regarding return value of UPDATe commands.
 
 ## [0.4.1] - 2023-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,3 +69,6 @@ in the pool should be checked if they are still valid
 [0.3.0]: https://github.com/weiznich/diesel_async/compare/v0.2.0...v0.3.0
 [0.3.1]: https://github.com/weiznich/diesel_async/compare/v0.3.0...v0.3.1
 [0.3.2]: https://github.com/weiznich/diesel_async/compare/v0.3.1...v0.3.2
+[0.4.0]: https://github.com/weiznich/diesel_async/compare/v0.3.2...v0.4.0
+[0.4.1]: https://github.com/weiznich/diesel_async/compare/v0.4.0...v0.4.1
+[Unreleased]: https://github.com/weiznich/diesel_async/compare/v0.4.1...main

--- a/src/mysql/mod.rs
+++ b/src/mysql/mod.rs
@@ -57,7 +57,8 @@ impl AsyncConnection for AsyncMysqlConnection {
             .map_err(|e| diesel::result::ConnectionError::InvalidConnectionUrl(e.to_string()))?;
         let builder = OptsBuilder::from_opts(opts)
             .init(CONNECTION_SETUP_QUERIES.to_vec())
-            .stmt_cache_size(0); // We have our own cache
+            .stmt_cache_size(0) // We have our own cache
+            .client_found_rows(true); // This allows a consistent behavior between MariaDB/MySQL and PostgreSQL (and is already set in `diesel`)
 
         let conn = mysql_async::Conn::new(builder).await.map_err(ErrorHelper)?;
 


### PR DESCRIPTION
This MR fixes #138 , and also adds a few missing links in CHANGELOG.md .