### PR TITLE
Update Rustls example and add to README for clarification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,18 @@ jobs:
 
       - name: Set environment variables
         shell: bash
+        if: matrix.backend == 'postgres' && matrix.os == 'windows-2019'
+        run: |
+          echo "AWS_LC_SYS_NO_ASM=1"
+
+      - name: Set environment variables
+        shell: bash
         if: matrix.rust == 'nightly'
         run: |
           echo "RUSTFLAGS=--cap-lints=warn" >> $GITHUB_ENV
+
+      - uses: ilammy/setup-nasm@v1
+        if: matrix.backend == 'postgres' && matrix.os == 'windows-2019'
 
       - name: Install postgres (Linux)
         if: runner.os == 'Linux' && matrix.backend == 'postgres'

--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ let mut conn = pool.get().await?;
 let res = users::table.select(User::as_select()).load::(&mut conn).await?;
 ```
 
+## Diesel-Async with Secure Database
+
+In the event of using this crate with a `sslmode=require` flag, it will be necessary to build a TLS cert.
+There is an example provided for doing this using the `rustls` crate in the `postgres` examples folder.
+
 ## Crate Feature Flags
 
 Diesel-async offers several configurable features:

--- a/examples/postgres/pooled-with-rustls/Cargo.toml
+++ b/examples/postgres/pooled-with-rustls/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-diesel = { version = "2.1.0", default-features = false, features = ["postgres"] }
+diesel = { version = "2.2.0", default-features = false, features = ["postgres"] }
 diesel-async = { version = "0.4.0", path = "../../../", features = ["bb8", "postgres"] }
 futures-util = "0.3.21"
-rustls = "0.20.8"
-rustls-native-certs = "0.6.2"
+rustls = "0.23.8"
+rustls-native-certs = "0.7.1"
 tokio = { version = "1.2.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 tokio-postgres = "0.7.7"
-tokio-postgres-rustls = "0.9.0"
+tokio-postgres-rustls = "0.12.0"

--- a/examples/postgres/pooled-with-rustls/src/main.rs
+++ b/examples/postgres/pooled-with-rustls/src/main.rs
@@ -43,7 +43,6 @@ fn establish_connection(config: &str) -> BoxFuture<ConnectionResult<AsyncPgConne
     let fut = async {
         // We first set up the way we want rustls to work.
         let rustls_config = rustls::ClientConfig::builder()
-            .with_safe_defaults()
             .with_root_certificates(root_certs())
             .with_no_client_auth();
         let tls = tokio_postgres_rustls::MakeRustlsConnect::new(rustls_config);

--- a/examples/postgres/pooled-with-rustls/src/main.rs
+++ b/examples/postgres/pooled-with-rustls/src/main.rs
@@ -63,7 +63,6 @@ fn establish_connection(config: &str) -> BoxFuture<ConnectionResult<AsyncPgConne
 fn root_certs() -> rustls::RootCertStore {
     let mut roots = rustls::RootCertStore::empty();
     let certs = rustls_native_certs::load_native_certs().expect("Certs not loadable!");
-    let certs: Vec<_> = certs.into_iter().map(|cert| cert.0).collect();
-    roots.add_parsable_certificates(&certs);
+    roots.add_parsable_certificates(certs);
     roots
 }

--- a/examples/postgres/run-pending-migrations-with-rustls/Cargo.toml
+++ b/examples/postgres/run-pending-migrations-with-rustls/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-diesel = { version = "2.1.0", default-features = false, features = ["postgres"] }
+diesel = { version = "2.2.0", default-features = false, features = ["postgres"] }
 diesel-async = { version = "0.4.0", path = "../../../", features = ["bb8", "postgres", "async-connection-wrapper"] }
-diesel_migrations = "2.1.0"
+diesel_migrations = "2.2.0"
 futures-util = "0.3.21"
-rustls = "0.20.8"
-rustls-native-certs = "0.6.2"
+rustls = "0.23.10"
+rustls-native-certs = "0.7.1"
 tokio = { version = "1.2.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 tokio-postgres = "0.7.7"
-tokio-postgres-rustls = "0.9.0"
+tokio-postgres-rustls = "0.12.0"

--- a/examples/postgres/run-pending-migrations-with-rustls/src/main.rs
+++ b/examples/postgres/run-pending-migrations-with-rustls/src/main.rs
@@ -29,7 +29,6 @@ fn establish_connection(config: &str) -> BoxFuture<ConnectionResult<AsyncPgConne
     let fut = async {
         // We first set up the way we want rustls to work.
         let rustls_config = rustls::ClientConfig::builder()
-            .with_safe_defaults()
             .with_root_certificates(root_certs())
             .with_no_client_auth();
         let tls = tokio_postgres_rustls::MakeRustlsConnect::new(rustls_config);
@@ -49,7 +48,6 @@ fn establish_connection(config: &str) -> BoxFuture<ConnectionResult<AsyncPgConne
 fn root_certs() -> rustls::RootCertStore {
     let mut roots = rustls::RootCertStore::empty();
     let certs = rustls_native_certs::load_native_certs().expect("Certs not loadable!");
-    let certs: Vec<_> = certs.into_iter().map(|cert| cert.0).collect();
-    roots.add_parsable_certificates(&certs);
+    roots.add_parsable_certificates(certs);
     roots
 }


### PR DESCRIPTION
As of December 2023 there was a change in the rustls crate that no long requires the collection of certs in a vec, I removed that and change the param for the next function accordingly. Also included a short blurb in the readme to specifically mention the requirement for tls if using an sslmode=require database