### PR TITLE
opt out of `Send` for wasm32

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,8 @@ pub use self::transaction_manager::{AnsiTransactionManager, TransactionManager};
 /// Perform simple operations on a backend.
 ///
 /// You should likely use [`AsyncConnection`] instead.
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait SimpleAsyncConnection {
     /// Execute multiple SQL statements within the same string.
     ///
@@ -129,7 +130,8 @@ pub trait SimpleAsyncConnection {
 /// This trait represents a n async database connection. It can be used to query the database through
 /// the query dsl provided by diesel, custom extensions or raw sql queries. It essentially mirrors
 /// the sync diesel [`Connection`](diesel::connection::Connection) implementation
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait AsyncConnection: SimpleAsyncConnection + Sized + Send {
     /// The future returned by `AsyncConnection::execute`
     type ExecuteFuture<'conn, 'query>: Future<Output = QueryResult<usize>> + Send;

--- a/src/pooled_connection/mod.rs
+++ b/src/pooled_connection/mod.rs
@@ -293,6 +293,7 @@ where
     }
 }
 
+#[allow(dead_code)]
 #[derive(diesel::query_builder::QueryId)]
 struct CheckConnectionQuery;
 

--- a/src/run_query_dsl/mod.rs
+++ b/src/run_query_dsl/mod.rs
@@ -695,7 +695,8 @@ impl<T, Conn> RunQueryDsl<Conn> for T {}
 /// #     Ok(())
 /// # }
 /// ```
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait SaveChangesDsl<Conn> {
     /// See the trait documentation
     async fn save_changes<T>(self, connection: &mut Conn) -> QueryResult<T>
@@ -722,7 +723,8 @@ impl<T, Conn> SaveChangesDsl<Conn> for T where
 /// For implementing this trait for a custom backend:
 /// * The `Changes` generic parameter represents the changeset that should be stored
 /// * The `Output` generic parameter represents the type of the response.
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait UpdateAndFetchResults<Changes, Output>: AsyncConnection
 where
     Changes: diesel::prelude::Identifiable + HasTable,

--- a/src/stmt_cache.rs
+++ b/src/stmt_cache.rs
@@ -18,7 +18,8 @@ type PrepareFuture<'a, F, S> = future::Either<
     future::BoxFuture<'a, QueryResult<(MaybeCached<'a, S>, F)>>,
 >;
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait PrepareCallback<S, M>: Sized {
     async fn prepare(
         self,

--- a/src/transaction_manager.rs
+++ b/src/transaction_manager.rs
@@ -16,7 +16,8 @@ use crate::AsyncConnection;
 ///
 /// You will not need to interact with this trait, unless you are writing an
 /// implementation of [`AsyncConnection`].
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait TransactionManager<Conn: AsyncConnection>: Send {
     /// Data stored as part of the connection implementation
     /// to track the current transaction state of a connection
@@ -287,7 +288,8 @@ impl AnsiTransactionManager {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl<Conn> TransactionManager<Conn> for AnsiTransactionManager
 where
     Conn: AsyncConnection<TransactionManager = Self>,


### PR DESCRIPTION
I'm working on adding a Wasm SQLite Backend to Diesel with the newly released [`wa-sqlite`](https://github.com/rhashimoto/wa-sqlite). 


Lots of functions for wa-sqlite are async and cannot be made sync in a wasm environment through blocking (b/c web). This means i've turned to this crate to try and continue to get it working, but this crate requires `Send` for it's Connection/diesel traits. This PR relaxes that condition for wasm32 environment.