### PR TITLE
Add Clone for SyncConnectionWrapper

### DIFF
--- a/src/sync_connection_wrapper/mod.rs
+++ b/src/sync_connection_wrapper/mod.rs
@@ -354,6 +354,14 @@ impl<C> SyncConnectionWrapper<C> {
     }
 }
 
+impl<C> Clone for SyncConnectionWrapper<C> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone()
+        }
+    }
+}
+
 #[cfg(any(
     feature = "deadpool",
     feature = "bb8",


### PR DESCRIPTION
Clone is needed for some async stuff like teloxide.

See discussion in https://github.com/teloxide/teloxide/discussions/1124