### PR TITLE
Enable a few more lints regarding truncations in numerical casts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## [Unreleased]
 
+## [0.5.1] - 2024-11-01
+
 * Add crate feature `pool` for extending connection pool implements through external crate
+* Implement `Deref` and `DerefMut` for `AsyncConnectionWrapper` to allow using it in an async context as well
 
 ## [0.5.0] - 2024-07-19
 
@@ -79,4 +82,5 @@ in the pool should be checked if they are still valid
 [0.4.0]: https://github.com/weiznich/diesel_async/compare/v0.3.2...v0.4.0
 [0.4.1]: https://github.com/weiznich/diesel_async/compare/v0.4.0...v0.4.1
 [0.5.0]: https://github.com/weiznich/diesel_async/compare/v0.4.0...v0.5.0
-[Unreleased]: https://github.com/weiznich/diesel_async/compare/v0.5.0...main
+[0.5.1]: https://github.com/weiznich/diesel_async/compare/v0.5.0...v0.5.1
+[Unreleased]: https://github.com/weiznich/diesel_async/compare/v0.5.1...main

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel-async"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Georg Semmler <github@weiznich.de>"]
 edition = "2021"
 autotests = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,12 @@
 //! # }
 //! ```
 
-#![warn(missing_docs)]
+#![warn(
+    missing_docs,
+    clippy::cast_possible_wrap,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
 
 use diesel::backend::Backend;
 use diesel::connection::Instrumentation;

--- a/src/mysql/row.rs
+++ b/src/mysql/row.rs
@@ -99,7 +99,12 @@ impl<'a> diesel::row::Row<'a, Mysql> for MysqlRow {
                 Some(Cow::Owned(buffer))
             }
             _t => {
-                let mut buffer = Vec::with_capacity(value.bin_len() as usize);
+                let mut buffer = Vec::with_capacity(
+                    value
+                        .bin_len()
+                        .try_into()
+                        .expect("Failed to cast byte size to usize"),
+                );
                 mysql_common::proto::MySerialize::serialize(value, &mut buffer);
                 Some(Cow::Owned(buffer))
             }

--- a/src/pg/error_helper.rs
+++ b/src/pg/error_helper.rs
@@ -81,9 +81,9 @@ impl diesel::result::DatabaseErrorInformation for PostgresDbErrorWrapper {
 
     fn statement_position(&self) -> Option<i32> {
         use tokio_postgres::error::ErrorPosition;
-        self.0.position().map(|e| match e {
+        self.0.position().and_then(|e| match *e {
             ErrorPosition::Original(position) | ErrorPosition::Internal { position, .. } => {
-                *position as i32
+                position.try_into().ok()
             }
         })
     }

--- a/src/pg/mod.rs
+++ b/src/pg/mod.rs
@@ -274,7 +274,8 @@ async fn execute_prepared(
     let res = tokio_postgres::Client::execute(&conn, &stmt, &binds as &[_])
         .await
         .map_err(ErrorHelper)?;
-    Ok(res as usize)
+    res.try_into()
+        .map_err(|e| diesel::result::Error::DeserializationError(Box::new(e)))
 }
 
 #[inline(always)]

--- a/tests/instrumentation.rs
+++ b/tests/instrumentation.rs
@@ -116,7 +116,7 @@ async fn check_events_are_emitted_for_load() {
 async fn check_events_are_emitted_for_execute_returning_count_does_not_contain_cache_for_uncached_queries(
 ) {
     let (events_to_check, mut conn) = setup_test_case().await;
-    conn.execute_returning_count(&diesel::sql_query("select 1"))
+    conn.execute_returning_count(diesel::sql_query("select 1"))
         .await
         .unwrap();
     let events = events_to_check.lock().unwrap();
@@ -141,7 +141,7 @@ async fn check_events_are_emitted_for_load_does_not_contain_cache_for_uncached_q
 async fn check_events_are_emitted_for_execute_returning_count_does_contain_error_for_failures() {
     let (events_to_check, mut conn) = setup_test_case().await;
     let _ = conn
-        .execute_returning_count(&diesel::sql_query("invalid"))
+        .execute_returning_count(diesel::sql_query("invalid"))
         .await;
     let events = events_to_check.lock().unwrap();
     assert_eq!(events.len(), 2, "{:?}", events);

--- a/tests/pooling.rs
+++ b/tests/pooling.rs
@@ -17,7 +17,7 @@ async fn save_changes_bb8() {
 
     let mut conn = pool.get().await.unwrap();
 
-    super::setup(&mut *conn).await;
+    super::setup(&mut conn).await;
 
     diesel::insert_into(users::table)
         .values(users::name.eq("John"))
@@ -51,7 +51,7 @@ async fn save_changes_deadpool() {
 
     let mut conn = pool.get().await.unwrap();
 
-    super::setup(&mut *conn).await;
+    super::setup(&mut conn).await;
 
     diesel::insert_into(users::table)
         .values(users::name.eq("John"))
@@ -85,7 +85,7 @@ async fn save_changes_mobc() {
 
     let mut conn = pool.get().await.unwrap();
 
-    super::setup(&mut *conn).await;
+    super::setup(&mut conn).await;
 
     diesel::insert_into(users::table)
         .values(users::name.eq("John"))

--- a/tests/type_check.rs
+++ b/tests/type_check.rs
@@ -200,8 +200,8 @@ async fn test_datetime() {
     type_check::<_, sql_types::Datetime>(
         conn,
         chrono::NaiveDateTime::new(
-            chrono::NaiveDate::from_ymd_opt(2021, 09, 30).unwrap(),
-            chrono::NaiveTime::from_hms_milli_opt(12, 06, 42, 0).unwrap(),
+            chrono::NaiveDate::from_ymd_opt(2021, 9, 30).unwrap(),
+            chrono::NaiveTime::from_hms_milli_opt(12, 6, 42, 0).unwrap(),
         ),
     )
     .await;


### PR DESCRIPTION
This is similar to https://github.com/diesel-rs/diesel/pull/4170, it's just not a serve as the diesel change as we do not found any critical cast here. I also investigated the implementation in the postgres crate and it seems to be fine as well (i.e error on too large buffer sizes instead silently truncating)