### PR TITLE
Error handling for `tokio_postgres::Connection` created manually

### DIFF
--- a/examples/postgres/pooled-with-rustls/src/main.rs
+++ b/examples/postgres/pooled-with-rustls/src/main.rs
@@ -49,12 +49,8 @@ fn establish_connection(config: &str) -> BoxFuture<ConnectionResult<AsyncPgConne
         let (client, conn) = tokio_postgres::connect(config, tls)
             .await
             .map_err(|e| ConnectionError::BadConnection(e.to_string()))?;
-        tokio::spawn(async move {
-            if let Err(e) = conn.await {
-                eprintln!("Database connection: {e}");
-            }
-        });
-        AsyncPgConnection::try_from(client).await
+
+        AsyncPgConnection::try_from_client_and_connection(client, conn).await
     };
     fut.boxed()
 }

--- a/examples/postgres/run-pending-migrations-with-rustls/src/main.rs
+++ b/examples/postgres/run-pending-migrations-with-rustls/src/main.rs
@@ -35,12 +35,7 @@ fn establish_connection(config: &str) -> BoxFuture<ConnectionResult<AsyncPgConne
         let (client, conn) = tokio_postgres::connect(config, tls)
             .await
             .map_err(|e| ConnectionError::BadConnection(e.to_string()))?;
-        tokio::spawn(async move {
-            if let Err(e) = conn.await {
-                eprintln!("Database connection: {e}");
-            }
-        });
-        AsyncPgConnection::try_from(client).await
+        AsyncPgConnection::try_from_client_and_connection(client, conn).await
     };
     fut.boxed()
 }


### PR DESCRIPTION
Related discussion: #184 

I was struggling a little bit to write docs that didn't leak too much of the implementation details, so I chose to keep it minimal. Happy to push fixups.

* Adds a new method `AsyncPgConnection::try_from_client_and_connection` that handles the details of driving the underlying `tokio_postgres::Connection`. Connections constructed using this method will now benefit from the same error handling provided by `AsyncPgConnection::establish`.

* Adds a small section about TLS to the `AsyncPgConnection` documentation.

* Updates the TLS examples for Postgres to use the new method.