### PR TITLE
CI: Run `async-connection-wrapper` feature tests too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
         run: cargo +${{ matrix.rust }} version
 
       - name: Test diesel_async
-        run: cargo +${{ matrix.rust }} test --manifest-path Cargo.toml --no-default-features --features "${{ matrix.backend }} deadpool bb8 mobc"
+        run: cargo +${{ matrix.rust }} test --manifest-path Cargo.toml --no-default-features --features "${{ matrix.backend }} deadpool bb8 mobc async-connection-wrapper"
 
       - name: Run examples (Postgres)
         if: matrix.backend == 'postgres'

--- a/src/async_connection_wrapper.rs
+++ b/src/async_connection_wrapper.rs
@@ -43,7 +43,7 @@ pub trait BlockOn {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```rust,no_run
 /// # include!("doctest_setup.rs");
 /// use schema::users;
 /// use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
@@ -61,7 +61,7 @@ pub trait BlockOn {
 ///
 /// If you are in the scope of an existing tokio runtime you need to use
 /// `tokio::task::spawn_blocking` to encapsulate the blocking tasks
-/// ```rust
+/// ```rust,no_run
 /// # include!("doctest_setup.rs");
 /// use schema::users;
 /// use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;

--- a/tests/sync_wrapper.rs
+++ b/tests/sync_wrapper.rs
@@ -6,6 +6,17 @@ use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 fn test_sync_wrapper() {
     use diesel::RunQueryDsl;
 
+    // The runtime is required for the `sqlite` implementation to be able to use
+    // `spawn_blocking()`. This is not required for `postgres` or `mysql`.
+    #[cfg(feature = "sqlite")]
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .unwrap();
+
+    #[cfg(feature = "sqlite")]
+    let _guard = rt.enter();
+
     let db_url = std::env::var("DATABASE_URL").unwrap();
     let mut conn = AsyncConnectionWrapper::<crate::TestConnection>::establish(&db_url).unwrap();
 


### PR DESCRIPTION
`tests/sync_wrapper.rs` is gated by `#[cfg(feature = "async-connection-wrapper")]`. Since the `async-connection-wrapper` feature wasn't explicitly enabled, we were not actually running these tests on CI.