### PR TITLE
AsyncConnectionWrapper: Implement `Deref<Target = C>`

### DIFF
--- a/src/async_connection_wrapper.rs
+++ b/src/async_connection_wrapper.rs
@@ -101,6 +101,7 @@ pub use self::implementation::AsyncConnectionWrapper;
 
 mod implementation {
     use diesel::connection::{Instrumentation, SimpleConnection};
+    use std::ops::{Deref, DerefMut};
 
     use super::*;
 
@@ -119,6 +120,20 @@ mod implementation {
                 inner,
                 runtime: B::get_runtime(),
             }
+        }
+    }
+
+    impl<C, B> Deref for AsyncConnectionWrapper<C, B> {
+        type Target = C;
+
+        fn deref(&self) -> &Self::Target {
+            &self.inner
+        }
+    }
+
+    impl<C, B> DerefMut for AsyncConnectionWrapper<C, B> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.inner
         }
     }
 

--- a/tests/sync_wrapper.rs
+++ b/tests/sync_wrapper.rs
@@ -1,9 +1,11 @@
 use diesel::migration::Migration;
-use diesel::prelude::*;
+use diesel::{Connection, IntoSql};
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 
 #[test]
 fn test_sync_wrapper() {
+    use diesel::RunQueryDsl;
+
     let db_url = std::env::var("DATABASE_URL").unwrap();
     let mut conn = AsyncConnectionWrapper::<crate::TestConnection>::establish(&db_url).unwrap();
 
@@ -13,7 +15,23 @@ fn test_sync_wrapper() {
 }
 
 #[tokio::test]
+async fn test_sync_wrapper_async_query() {
+    use diesel_async::{AsyncConnection, RunQueryDsl};
+
+    let db_url = std::env::var("DATABASE_URL").unwrap();
+    let conn = crate::TestConnection::establish(&db_url).await.unwrap();
+    let mut conn = AsyncConnectionWrapper::<_>::from(conn);
+
+    let res = diesel::select(1.into_sql::<diesel::sql_types::Integer>())
+        .get_result::<i32>(&mut conn)
+        .await;
+    assert_eq!(Ok(1), res);
+}
+
+#[tokio::test]
 async fn test_sync_wrapper_under_runtime() {
+    use diesel::RunQueryDsl;
+
     let db_url = std::env::var("DATABASE_URL").unwrap();
     tokio::task::spawn_blocking(move || {
         let mut conn = AsyncConnectionWrapper::<crate::TestConnection>::establish(&db_url).unwrap();


### PR DESCRIPTION
This allows us to use an `AsyncConnectionWrapper` instance with sync **and** async queries, which should slightly ease the migration from sync to async.