### PR TITLE
pg: Remove `pub` from `tests` module declaration

### DIFF
--- a/src/pg/mod.rs
+++ b/src/pg/mod.rs
@@ -894,7 +894,7 @@ impl crate::pooled_connection::PoolableConnection for AsyncPgConnection {
 }
 
 #[cfg(test)]
-pub mod tests {
+mod tests {
     use super::*;
     use crate::run_query_dsl::RunQueryDsl;
     use diesel::sql_types::Integer;


### PR DESCRIPTION
This should hopefully fix the `missing_docs` warning on the most recent Rust 1.83 beta release.