### PR TITLE
Derive Debug for SyncConnectionWrapper

### DIFF
--- a/src/sync_connection_wrapper/mod.rs
+++ b/src/sync_connection_wrapper/mod.rs
@@ -73,6 +73,7 @@ fn from_tokio_join_error(join_error: JoinError) -> diesel::result::Error {
 /// #    some_async_fn().await;
 /// # }
 /// ```
+#[derive(Debug)]
 pub struct SyncConnectionWrapper<C> {
     inner: Arc<Mutex<C>>,
 }


### PR DESCRIPTION
This is needed when trying to use [tower-sessions](https://crates.io/crates/tower-sessions) with this crate. `tower-sessions` requires `Debug` for the provided backend store. In my particular case the store looks like:

```rust
type SqlitePool = deadpool::Pool<SyncConnectionWrapper<sqlite::SqliteConnection>>;

#[derive(Clone, Debug)]
pub struct AsyncSqliteStore {
    pool: SqlitePool,
}
```

The error without this `Debug` impl is:

```
`diesel_async::sync_connection_wrapper::SyncConnectionWrapper<diesel::SqliteConnection>` doesn't implement `std::fmt::Debug`
the trait `std::fmt::Debug` is not implemented for `diesel_async::sync_connection_wrapper::SyncConnectionWrapper<diesel::SqliteConnection>`, which is required by `deadpool::managed::Pool<diesel_async::pooled_connection::AsyncDieselConnectionManager<diesel_async::sync_connection_wrapper::SyncConnectionWrapper<diesel::SqliteConnection>>>: std::fmt::Debug`
```
