### PR TITLE
chore: upgrade `bb8` to `v9.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,27 +14,27 @@ rust-version = "1.78.0"
 
 [dependencies]
 diesel = { version = "~2.2.0", default-features = false, features = [
-        "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
+  "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
 ] }
 async-trait = "0.1.66"
 futures-channel = { version = "0.3.17", default-features = false, features = [
-        "std",
-        "sink",
+  "std",
+  "sink",
 ], optional = true }
 futures-util = { version = "0.3.17", default-features = false, features = [
-        "std",
-        "sink",
+  "std",
+  "sink",
 ] }
 tokio-postgres = { version = "0.7.10", optional = true }
 tokio = { version = "1.26", optional = true }
 mysql_async = { version = "0.34", optional = true, default-features = false, features = [
-        "minimal-rust",
+  "minimal-rust",
 ] }
 mysql_common = { version = "0.32", optional = true, default-features = false }
 
-bb8 = { version = "0.8", optional = true }
+bb8 = { version = "0.9", optional = true }
 deadpool = { version = "0.12", optional = true, default-features = false, features = [
-        "managed",
+  "managed",
 ] }
 mobc = { version = ">=0.7,<0.10", optional = true }
 scoped-futures = { version = "0.1", features = ["std"] }
@@ -50,11 +50,11 @@ assert_matches = "1.0.1"
 [features]
 default = []
 mysql = [
-        "diesel/mysql_backend",
-        "mysql_async",
-        "mysql_common",
-        "futures-channel",
-        "tokio",
+  "diesel/mysql_backend",
+  "mysql_async",
+  "mysql_common",
+  "futures-channel",
+  "tokio",
 ]
 postgres = ["diesel/postgres_backend", "tokio-postgres", "tokio", "tokio/rt"]
 sqlite = ["diesel/sqlite", "sync-connection-wrapper"]
@@ -73,15 +73,15 @@ harness = true
 
 [package.metadata.docs.rs]
 features = [
-        "postgres",
-        "mysql",
-        "sqlite",
-        "deadpool",
-        "bb8",
-        "mobc",
-        "async-connection-wrapper",
-        "sync-connection-wrapper",
-        "r2d2",
+  "postgres",
+  "mysql",
+  "sqlite",
+  "deadpool",
+  "bb8",
+  "mobc",
+  "async-connection-wrapper",
+  "sync-connection-wrapper",
+  "r2d2",
 ]
 no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
@@ -89,8 +89,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace]
 members = [
-        ".",
-        "examples/postgres/pooled-with-rustls",
-        "examples/postgres/run-pending-migrations-with-rustls",
-        "examples/sync-wrapper",
+  ".",
+  "examples/postgres/pooled-with-rustls",
+  "examples/postgres/run-pending-migrations-with-rustls",
+  "examples/sync-wrapper",
 ]

--- a/src/async_connection_wrapper.rs
+++ b/src/async_connection_wrapper.rs
@@ -194,13 +194,15 @@ mod implementation {
         C: crate::AsyncConnection,
         B: BlockOn + Send,
     {
-        type Cursor<'conn, 'query> = AsyncCursorWrapper<'conn, C::Stream<'conn, 'query>, B>
-    where
-        Self: 'conn;
+        type Cursor<'conn, 'query>
+            = AsyncCursorWrapper<'conn, C::Stream<'conn, 'query>, B>
+        where
+            Self: 'conn;
 
-        type Row<'conn, 'query> = C::Row<'conn, 'query>
-    where
-        Self: 'conn;
+        type Row<'conn, 'query>
+            = C::Row<'conn, 'query>
+        where
+            Self: 'conn;
 
         fn load<'conn, 'query, T>(
             &'conn mut self,

--- a/src/mysql/row.rs
+++ b/src/mysql/row.rs
@@ -37,7 +37,11 @@ impl RowSealed for MysqlRow {}
 
 impl<'a> diesel::row::Row<'a, Mysql> for MysqlRow {
     type InnerPartialRow = Self;
-    type Field<'b> = MysqlField<'b> where Self: 'b, 'a: 'b;
+    type Field<'b>
+        = MysqlField<'b>
+    where
+        Self: 'b,
+        'a: 'b;
 
     fn field_count(&self) -> usize {
         self.0.columns_ref().len()

--- a/src/pg/row.rs
+++ b/src/pg/row.rs
@@ -16,7 +16,11 @@ impl RowSealed for PgRow {}
 
 impl<'a> diesel::row::Row<'a, diesel::pg::Pg> for PgRow {
     type InnerPartialRow = Self;
-    type Field<'b> = PgField<'b> where Self: 'b, 'a: 'b;
+    type Field<'b>
+        = PgField<'b>
+    where
+        Self: 'b,
+        'a: 'b;
 
     fn field_count(&self) -> usize {
         self.row.len()

--- a/src/pooled_connection/bb8.rs
+++ b/src/pooled_connection/bb8.rs
@@ -65,7 +65,6 @@ pub type PooledConnection<'a, C> = bb8::PooledConnection<'a, AsyncDieselConnecti
 /// Type alias for using [`bb8::RunError`] with [`diesel-async`]
 pub type RunError = bb8::RunError<super::PoolError>;
 
-#[async_trait::async_trait]
 impl<C> ManageConnection for AsyncDieselConnectionManager<C>
 where
     C: PoolableConnection + 'static,

--- a/src/run_query_dsl/mod.rs
+++ b/src/run_query_dsl/mod.rs
@@ -92,17 +92,21 @@ pub mod methods {
         DB: QueryMetadata<T::SqlType>,
         ST: 'static,
     {
-        type LoadFuture<'conn> = future::MapOk<
+        type LoadFuture<'conn>
+            = future::MapOk<
             Conn::LoadFuture<'conn, 'query>,
             fn(Conn::Stream<'conn, 'query>) -> Self::Stream<'conn>,
-        > where Conn: 'conn;
+        >
+        where
+            Conn: 'conn;
 
-        type Stream<'conn> = stream::Map<
+        type Stream<'conn>
+            = stream::Map<
             Conn::Stream<'conn, 'query>,
-            fn(
-                QueryResult<Conn::Row<'conn, 'query>>,
-            ) -> QueryResult<U>,
-        >where  Conn: 'conn;
+            fn(QueryResult<Conn::Row<'conn, 'query>>) -> QueryResult<U>,
+        >
+        where
+            Conn: 'conn;
 
         fn internal_load(self, conn: &mut Conn) -> Self::LoadFuture<'_> {
             conn.load(self)


### PR DESCRIPTION
`bb8` `v9.0` dropped `async_trait` and bumped MSRV to `v1.75.0` which is already compatible with this library's MSRV `v1.78.0`.