### PR TITLE
Share the statement cache with diesel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,6 @@ description = "An async extension for Diesel the safe, extensible ORM and Query 
 rust-version = "1.78.0"
 
 [dependencies]
-diesel = { version = "~2.2.0", default-features = false, features = [
-  "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
-] }
 async-trait = "0.1.66"
 futures-channel = { version = "0.3.17", default-features = false, features = [
   "std",
@@ -39,13 +36,34 @@ deadpool = { version = "0.12", optional = true, default-features = false, featur
 mobc = { version = ">=0.7,<0.10", optional = true }
 scoped-futures = { version = "0.1", features = ["std"] }
 
+[dependencies.diesel]
+version = "~2.2.0"
+default-features = false
+features = [
+  "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
+]
+git = "https://github.com/diesel-rs/diesel"
+branch = "master"
+
 [dev-dependencies]
 tokio = { version = "1.12.0", features = ["rt", "macros", "rt-multi-thread"] }
 cfg-if = "1"
 chrono = "0.4"
-diesel = { version = "2.2.0", default-features = false, features = ["chrono"] }
-diesel_migrations = "2.2.0"
 assert_matches = "1.0.1"
+
+[dev-dependencies.diesel]
+version = "~2.2.0"
+default-features = false
+features = [
+  "chrono"
+]
+git = "https://github.com/diesel-rs/diesel"
+branch = "master"
+
+[dev-dependencies.diesel_migrations]
+version = "2.2.0"
+git = "https://github.com/diesel-rs/diesel"
+branch = "master"
 
 [features]
 default = []

--- a/examples/postgres/pooled-with-rustls/Cargo.toml
+++ b/examples/postgres/pooled-with-rustls/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-diesel = { version = "2.2.0", default-features = false, features = ["postgres"] }
 diesel-async = { version = "0.5.0", path = "../../../", features = ["bb8", "postgres"] }
 futures-util = "0.3.21"
 rustls = "0.23.8"
@@ -14,3 +13,10 @@ rustls-native-certs = "0.7.1"
 tokio = { version = "1.2.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 tokio-postgres = "0.7.7"
 tokio-postgres-rustls = "0.12.0"
+
+
+[dependencies.diesel]
+version = "2.2.0"
+default-features = false
+git = "https://github.com/diesel-rs/diesel"
+branch = "master"

--- a/examples/postgres/run-pending-migrations-with-rustls/Cargo.toml
+++ b/examples/postgres/run-pending-migrations-with-rustls/Cargo.toml
@@ -6,12 +6,21 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-diesel = { version = "2.2.0", default-features = false, features = ["postgres"] }
 diesel-async = { version = "0.5.0", path = "../../../", features = ["bb8", "postgres", "async-connection-wrapper"] }
-diesel_migrations = "2.2.0"
 futures-util = "0.3.21"
 rustls = "0.23.10"
 rustls-native-certs = "0.7.1"
 tokio = { version = "1.2.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 tokio-postgres = "0.7.7"
 tokio-postgres-rustls = "0.12.0"
+
+[dependencies.diesel]
+version = "2.2.0"
+default-features = false
+git = "https://github.com/diesel-rs/diesel"
+branch = "master"
+
+[dependencies.diesel_migrations]
+version = "2.2.0"
+git = "https://github.com/diesel-rs/diesel"
+branch = "master"

--- a/examples/sync-wrapper/Cargo.toml
+++ b/examples/sync-wrapper/Cargo.toml
@@ -6,11 +6,21 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-diesel = { version = "2.2.0", default-features = false, features = ["returning_clauses_for_sqlite_3_35"] }
 diesel-async = { version = "0.5.0", path = "../../", features = ["sync-connection-wrapper", "async-connection-wrapper"] }
-diesel_migrations = "2.2.0"
 futures-util = "0.3.21"
 tokio = { version = "1.2.0", default-features = false, features = ["macros", "rt-multi-thread"] }
+
+[dependencies.diesel]
+version = "2.2.0"
+default-features = false
+features = ["returning_clauses_for_sqlite_3_35"]
+git = "https://github.com/diesel-rs/diesel"
+branch = "master"
+
+[dependencies.diesel_migrations]
+version = "2.2.0"
+git = "https://github.com/diesel-rs/diesel"
+branch = "master"
 
 [features]
 default = ["sqlite"]

--- a/src/async_connection_wrapper.rs
+++ b/src/async_connection_wrapper.rs
@@ -100,7 +100,7 @@ pub type AsyncConnectionWrapper<C, B = self::implementation::Tokio> =
 pub use self::implementation::AsyncConnectionWrapper;
 
 mod implementation {
-    use diesel::connection::{Instrumentation, SimpleConnection};
+    use diesel::connection::{CacheSize, Instrumentation, SimpleConnection};
     use std::ops::{Deref, DerefMut};
 
     use super::*;
@@ -186,6 +186,10 @@ mod implementation {
 
         fn set_instrumentation(&mut self, instrumentation: impl Instrumentation) {
             self.inner.set_instrumentation(instrumentation);
+        }
+
+        fn set_prepared_statement_cache_size(&mut self, size: CacheSize) {
+            self.inner.set_prepared_statement_cache_size(size)
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@
 )]
 
 use diesel::backend::Backend;
-use diesel::connection::Instrumentation;
+use diesel::connection::{CacheSize, Instrumentation};
 use diesel::query_builder::{AsQuery, QueryFragment, QueryId};
 use diesel::result::Error;
 use diesel::row::Row;
@@ -354,4 +354,7 @@ pub trait AsyncConnection: SimpleAsyncConnection + Sized + Send {
 
     /// Set a specific [`Instrumentation`] implementation for this connection
     fn set_instrumentation(&mut self, instrumentation: impl Instrumentation);
+
+    /// Set the prepared statement cache size to [`CacheSize`] for this connection
+    fn set_prepared_statement_cache_size(&mut self, size: CacheSize);
 }

--- a/src/pooled_connection/mod.rs
+++ b/src/pooled_connection/mod.rs
@@ -8,7 +8,7 @@
 use crate::{AsyncConnection, SimpleAsyncConnection};
 use crate::{TransactionManager, UpdateAndFetchResults};
 use diesel::associations::HasTable;
-use diesel::connection::Instrumentation;
+use diesel::connection::{CacheSize, Instrumentation};
 use diesel::QueryResult;
 use futures_util::{future, FutureExt};
 use std::borrow::Cow;
@@ -240,6 +240,10 @@ where
 
     fn set_instrumentation(&mut self, instrumentation: impl Instrumentation) {
         self.deref_mut().set_instrumentation(instrumentation);
+    }
+
+    fn set_prepared_statement_cache_size(&mut self, size: CacheSize) {
+        self.deref_mut().set_prepared_statement_cache_size(size);
     }
 }
 


### PR DESCRIPTION
This commit refactors diesel-async to use the same statement cache implementation as diesel. That brings in all the optimisations done to the diesel statement cache.