### PR TITLE
[Update] examples to use rustls-platform-verifier

### DIFF
--- a/examples/postgres/pooled-with-rustls/Cargo.toml
+++ b/examples/postgres/pooled-with-rustls/Cargo.toml
@@ -10,7 +10,7 @@ diesel = { version = "2.2.0", default-features = false, features = ["postgres"] 
 diesel-async = { version = "0.5.0", path = "../../../", features = ["bb8", "postgres"] }
 futures-util = "0.3.21"
 rustls = "0.23.8"
-rustls-native-certs = "0.7.1"
+rustls-platform-verifier = "0.5.0"
 tokio = { version = "1.2.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 tokio-postgres = "0.7.7"
-tokio-postgres-rustls = "0.12.0"
+tokio-postgres-rustls = "0.13.0"

--- a/examples/postgres/pooled-with-rustls/src/main.rs
+++ b/examples/postgres/pooled-with-rustls/src/main.rs
@@ -5,6 +5,8 @@ use diesel_async::pooled_connection::ManagerConfig;
 use diesel_async::AsyncPgConnection;
 use futures_util::future::BoxFuture;
 use futures_util::FutureExt;
+use rustls::ClientConfig;
+use rustls_platform_verifier::ConfigVerifierExt;
 use std::time::Duration;
 
 #[tokio::main]
@@ -42,9 +44,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn establish_connection(config: &str) -> BoxFuture<ConnectionResult<AsyncPgConnection>> {
     let fut = async {
         // We first set up the way we want rustls to work.
-        let rustls_config = rustls::ClientConfig::builder()
-            .with_root_certificates(root_certs())
-            .with_no_client_auth();
+        let rustls_config = ClientConfig::with_platform_verifier();
         let tls = tokio_postgres_rustls::MakeRustlsConnect::new(rustls_config);
         let (client, conn) = tokio_postgres::connect(config, tls)
             .await
@@ -53,11 +53,4 @@ fn establish_connection(config: &str) -> BoxFuture<ConnectionResult<AsyncPgConne
         AsyncPgConnection::try_from_client_and_connection(client, conn).await
     };
     fut.boxed()
-}
-
-fn root_certs() -> rustls::RootCertStore {
-    let mut roots = rustls::RootCertStore::empty();
-    let certs = rustls_native_certs::load_native_certs().expect("Certs not loadable!");
-    roots.add_parsable_certificates(certs);
-    roots
 }

--- a/examples/postgres/run-pending-migrations-with-rustls/Cargo.toml
+++ b/examples/postgres/run-pending-migrations-with-rustls/Cargo.toml
@@ -10,8 +10,8 @@ diesel = { version = "2.2.0", default-features = false, features = ["postgres"] 
 diesel-async = { version = "0.5.0", path = "../../../", features = ["bb8", "postgres", "async-connection-wrapper"] }
 diesel_migrations = "2.2.0"
 futures-util = "0.3.21"
-rustls = "0.23.10"
-rustls-native-certs = "0.7.1"
+rustls = "0.23.8"
+rustls-platform-verifier = "0.5.0"
 tokio = { version = "1.2.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 tokio-postgres = "0.7.7"
-tokio-postgres-rustls = "0.12.0"
+tokio-postgres-rustls = "0.13.0"


### PR DESCRIPTION
Replace `rustls-native-certs` with `rustls-platform-verifier` which will default to the correct certs use based on platform. This is recommended by the `rustls-native-certs` owner and is still being used within the `rustls-platform-verifier`.