### PR TITLE
Drop async_trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ description = "An async extension for Diesel the safe, extensible ORM and Query 
 rust-version = "1.78.0"
 
 [dependencies]
-async-trait = "0.1.66"
 futures-channel = { version = "0.3.17", default-features = false, features = [
   "std",
   "sink",
@@ -30,6 +29,7 @@ mysql_async = { version = "0.34", optional = true, default-features = false, fea
 mysql_common = { version = "0.32", optional = true, default-features = false }
 
 bb8 = { version = "0.9", optional = true }
+async-trait = { version = "0.1.66", optional = true }
 deadpool = { version = "0.12", optional = true, default-features = false, features = [
   "managed",
 ] }
@@ -80,7 +80,7 @@ sync-connection-wrapper = ["tokio/rt"]
 async-connection-wrapper = ["tokio/net"]
 pool = []
 r2d2 = ["pool", "diesel/r2d2"]
-bb8 = ["pool", "dep:bb8"]
+bb8 = ["pool", "dep:bb8", "dep:async-trait"]
 mobc = ["pool", "dep:mobc"]
 deadpool = ["pool", "dep:deadpool"]
 

--- a/src/async_connection_wrapper.rs
+++ b/src/async_connection_wrapper.rs
@@ -234,7 +234,7 @@ mod implementation {
         runtime: &'a B,
     }
 
-    impl<'a, S, B> Iterator for AsyncCursorWrapper<'a, S, B>
+    impl<S, B> Iterator for AsyncCursorWrapper<'_, S, B>
     where
         S: Stream,
         B: BlockOn,

--- a/src/mysql/mod.rs
+++ b/src/mysql/mod.rs
@@ -34,7 +34,6 @@ pub struct AsyncMysqlConnection {
     instrumentation: DynInstrumentation,
 }
 
-#[async_trait::async_trait]
 impl SimpleAsyncConnection for AsyncMysqlConnection {
     async fn batch_execute(&mut self, query: &str) -> diesel::QueryResult<()> {
         self.instrumentation()
@@ -63,7 +62,6 @@ const CONNECTION_SETUP_QUERIES: &[&str] = &[
     "SET character_set_results = 'utf8mb4'",
 ];
 
-#[async_trait::async_trait]
 impl AsyncConnection for AsyncMysqlConnection {
     type ExecuteFuture<'conn, 'query> = BoxFuture<'conn, QueryResult<usize>>;
     type LoadFuture<'conn, 'query> = BoxFuture<'conn, QueryResult<Self::Stream<'conn, 'query>>>;
@@ -208,9 +206,9 @@ fn update_transaction_manager_status<T>(
     query_result
 }
 
-fn prepare_statement_helper<'a, 'b>(
+fn prepare_statement_helper<'a>(
     conn: &'a mut mysql_async::Conn,
-    sql: &'b str,
+    sql: &str,
     _is_for_cache: diesel::connection::statement_cache::PrepareForCache,
     _metadata: &[MysqlType],
 ) -> CallbackHelper<impl Future<Output = QueryResult<(Statement, &'a mut mysql_async::Conn)>> + Send>

--- a/src/mysql/row.rs
+++ b/src/mysql/row.rs
@@ -132,7 +132,7 @@ pub struct MysqlField<'a> {
     name: Cow<'a, str>,
 }
 
-impl<'a> diesel::row::Field<'a, Mysql> for MysqlField<'_> {
+impl diesel::row::Field<'_, Mysql> for MysqlField<'_> {
     fn field_name(&self) -> Option<&str> {
         Some(&*self.name)
     }

--- a/src/pg/mod.rs
+++ b/src/pg/mod.rs
@@ -133,7 +133,6 @@ pub struct AsyncPgConnection {
     instrumentation: Arc<std::sync::Mutex<DynInstrumentation>>,
 }
 
-#[async_trait::async_trait]
 impl SimpleAsyncConnection for AsyncPgConnection {
     async fn batch_execute(&mut self, query: &str) -> QueryResult<()> {
         self.record_instrumentation(InstrumentationEvent::start_query(&StrQueryHelper::new(
@@ -154,7 +153,6 @@ impl SimpleAsyncConnection for AsyncPgConnection {
     }
 }
 
-#[async_trait::async_trait]
 impl AsyncConnection for AsyncPgConnection {
     type LoadFuture<'conn, 'query> = BoxFuture<'query, QueryResult<Self::Stream<'conn, 'query>>>;
     type ExecuteFuture<'conn, 'query> = BoxFuture<'query, QueryResult<usize>>;
@@ -306,9 +304,9 @@ fn update_transaction_manager_status<T>(
     query_result
 }
 
-fn prepare_statement_helper<'a>(
+fn prepare_statement_helper(
     conn: Arc<tokio_postgres::Client>,
-    sql: &'a str,
+    sql: &str,
     _is_for_cache: PrepareForCache,
     metadata: &[PgTypeMetadata],
 ) -> CallbackHelper<

--- a/src/pg/transaction_builder.rs
+++ b/src/pg/transaction_builder.rs
@@ -310,7 +310,7 @@ where
     }
 }
 
-impl<'a, C> QueryFragment<Pg> for TransactionBuilder<'a, C> {
+impl<C> QueryFragment<Pg> for TransactionBuilder<'_, C> {
     fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.push_sql("BEGIN TRANSACTION");
         if let Some(ref isolation_level) = self.isolation_level {

--- a/src/pooled_connection/bb8.rs
+++ b/src/pooled_connection/bb8.rs
@@ -50,7 +50,6 @@
 //! #     Ok(())
 //! # }
 //! ```
-
 use super::{AsyncDieselConnectionManager, PoolError, PoolableConnection};
 use bb8::ManageConnection;
 use diesel::query_builder::QueryFragment;

--- a/src/pooled_connection/mod.rs
+++ b/src/pooled_connection/mod.rs
@@ -10,9 +10,11 @@ use crate::{TransactionManager, UpdateAndFetchResults};
 use diesel::associations::HasTable;
 use diesel::connection::{CacheSize, Instrumentation};
 use diesel::QueryResult;
+use futures_util::future::BoxFuture;
 use futures_util::{future, FutureExt};
 use std::borrow::Cow;
 use std::fmt;
+use std::future::Future;
 use std::ops::DerefMut;
 
 #[cfg(feature = "bb8")]
@@ -164,7 +166,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<C> SimpleAsyncConnection for C
 where
     C: DerefMut + Send,
@@ -176,7 +177,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<C> AsyncConnection for C
 where
     C: DerefMut + Send,
@@ -251,7 +251,6 @@ where
 #[allow(missing_debug_implementations)]
 pub struct PoolTransactionManager<TM>(std::marker::PhantomData<TM>);
 
-#[async_trait::async_trait]
 impl<C, TM> TransactionManager<C> for PoolTransactionManager<TM>
 where
     C: DerefMut + Send,
@@ -283,18 +282,22 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<Changes, Output, Conn> UpdateAndFetchResults<Changes, Output> for Conn
 where
     Conn: DerefMut + Send,
     Changes: diesel::prelude::Identifiable + HasTable + Send,
     Conn::Target: UpdateAndFetchResults<Changes, Output>,
 {
-    async fn update_and_fetch(&mut self, changeset: Changes) -> QueryResult<Output>
+    fn update_and_fetch<'conn, 'changes>(
+        &'conn mut self,
+        changeset: Changes,
+    ) -> BoxFuture<'changes, QueryResult<Output>>
     where
-        Changes: 'async_trait,
+        Changes: 'changes,
+        'conn: 'changes,
+        Self: 'changes,
     {
-        self.deref_mut().update_and_fetch(changeset).await
+        self.deref_mut().update_and_fetch(changeset)
     }
 }
 
@@ -321,13 +324,15 @@ impl diesel::query_builder::Query for CheckConnectionQuery {
 impl<C> diesel::query_dsl::RunQueryDsl<C> for CheckConnectionQuery {}
 
 #[doc(hidden)]
-#[async_trait::async_trait]
 pub trait PoolableConnection: AsyncConnection {
     /// Check if a connection is still valid
     ///
     /// The default implementation will perform a check based on the provided
     /// recycling method variant
-    async fn ping(&mut self, config: &RecyclingMethod<Self>) -> diesel::QueryResult<()>
+    fn ping(
+        &mut self,
+        config: &RecyclingMethod<Self>,
+    ) -> impl Future<Output = diesel::QueryResult<()>> + Send
     where
         for<'a> Self: 'a,
         diesel::dsl::select<diesel::dsl::AsExprOf<i32, diesel::sql_types::Integer>>:
@@ -337,19 +342,21 @@ pub trait PoolableConnection: AsyncConnection {
         use crate::run_query_dsl::RunQueryDsl;
         use diesel::IntoSql;
 
-        match config {
-            RecyclingMethod::Fast => Ok(()),
-            RecyclingMethod::Verified => {
-                diesel::select(1_i32.into_sql::<diesel::sql_types::Integer>())
+        async move {
+            match config {
+                RecyclingMethod::Fast => Ok(()),
+                RecyclingMethod::Verified => {
+                    diesel::select(1_i32.into_sql::<diesel::sql_types::Integer>())
+                        .execute(self)
+                        .await
+                        .map(|_| ())
+                }
+                RecyclingMethod::CustomQuery(query) => diesel::sql_query(query.as_ref())
                     .execute(self)
                     .await
-                    .map(|_| ())
+                    .map(|_| ()),
+                RecyclingMethod::CustomFunction(c) => c(self).await,
             }
-            RecyclingMethod::CustomQuery(query) => diesel::sql_query(query.as_ref())
-                .execute(self)
-                .await
-                .map(|_| ()),
-            RecyclingMethod::CustomFunction(c) => c(self).await,
         }
     }
 

--- a/src/stmt_cache.rs
+++ b/src/stmt_cache.rs
@@ -10,9 +10,9 @@ type PrepareFuture<'a, C, S> = future::Either<
     future::BoxFuture<'a, QueryResult<(MaybeCached<'a, S>, C)>>,
 >;
 
-impl<'b, S, F, C> StatementCallbackReturnType<S, C> for CallbackHelper<F>
+impl<S, F, C> StatementCallbackReturnType<S, C> for CallbackHelper<F>
 where
-    F: Future<Output = QueryResult<(S, C)>> + Send + 'b,
+    F: Future<Output = QueryResult<(S, C)>> + Send,
     S: 'static,
 {
     type Return<'a> = PrepareFuture<'a, C, S>;
@@ -32,7 +32,7 @@ where
         )
     }
 
-    fn map_to_cache<'a>(stmt: &'a mut S, conn: C) -> Self::Return<'a> {
+    fn map_to_cache(stmt: &mut S, conn: C) -> Self::Return<'_> {
         future::Either::Left(future::ready(Ok((MaybeCached::Cached(stmt), conn))))
     }
 

--- a/src/sync_connection_wrapper/mod.rs
+++ b/src/sync_connection_wrapper/mod.rs
@@ -77,7 +77,6 @@ pub struct SyncConnectionWrapper<C> {
     inner: Arc<Mutex<C>>,
 }
 
-#[async_trait::async_trait]
 impl<C> SimpleAsyncConnection for SyncConnectionWrapper<C>
 where
     C: diesel::connection::Connection + 'static,
@@ -89,7 +88,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<C, MD, O> AsyncConnection for SyncConnectionWrapper<C>
 where
     // Backend bounds
@@ -207,7 +205,6 @@ where
 /// A wrapper of a diesel transaction manager usable in async context.
 pub struct SyncTransactionManagerWrapper<T>(PhantomData<T>);
 
-#[async_trait::async_trait]
 impl<T, C> TransactionManager<SyncConnectionWrapper<C>> for SyncTransactionManagerWrapper<T>
 where
     SyncConnectionWrapper<C>: AsyncConnection,


### PR DESCRIPTION
This commit remove `#[async_trait::async_trait]` wherever possible

It mainly replaces it with the "new" `-> impl Future` support in traits. There are still a few places that need to continue to use `BoxFuture` instead due to bugs in rustc.