### PR TITLE
RunQueryDsl: match same trait constraints as diesel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,3 +115,6 @@ members = [
   "examples/postgres/run-pending-migrations-with-rustls",
   "examples/sync-wrapper",
 ]
+
+[patch.crates-io]
+diesel =  { git = "https://github.com/eakoli/diesel/", branch = "feat/run-query-dsl-marker-trait" }

--- a/src/run_query_dsl/mod.rs
+++ b/src/run_query_dsl/mod.rs
@@ -71,7 +71,7 @@ pub mod methods {
     /// to call `load` from generic code.
     ///
     /// [`RunQueryDsl`]: super::RunQueryDsl
-    pub trait LoadQuery<'query, Conn: AsyncConnectionCore, U>: RunQueryDsl<Conn> {
+    pub trait LoadQuery<'query, Conn: AsyncConnectionCore, U> {
         /// The future returned by [`LoadQuery::internal_load`]
         type LoadFuture<'conn>: Future<Output = QueryResult<Self::Stream<'conn>>> + Send
         where
@@ -91,7 +91,7 @@ pub mod methods {
         Conn: AsyncConnectionCore<Backend = DB>,
         U: Send,
         DB: Backend + 'static,
-        T: AsQuery + RunQueryDsl<Conn> + Send + 'query,
+        T: AsQuery + Send + 'query,
         T::Query: QueryFragment<DB> + QueryId + Send + 'query,
         T::SqlType: CompatibleType<U, DB, SqlType = ST>,
         U: FromSqlRow<ST, DB> + Send + 'static,
@@ -583,14 +583,14 @@ pub trait RunQueryDsl<Conn>: Sized {
         U: Send + 'conn,
         Conn: AsyncConnectionCore,
         Self: diesel::query_dsl::methods::LimitDsl,
-        diesel::dsl::Limit<Self>: methods::LoadQuery<'query, Conn, U> + Send + 'query,
+        diesel::dsl::Limit<Self>:
+            methods::LoadQuery<'query, Conn, U> + RunQueryDsl<Conn> + Send + 'query,
     {
         diesel::query_dsl::methods::LimitDsl::limit(self, 1).get_result(conn)
     }
 }
 
-// Use marker trait to implement RunQueryDsl
-impl<T, Conn> RunQueryDsl<Conn> for T where T: diesel::query_dsl::SupportRunQueryDsl {}
+impl<T, Conn> RunQueryDsl<Conn> for T where T: diesel::query_dsl::RunQueryDslSupport {}
 
 /// Sugar for types which implement both `AsChangeset` and `Identifiable`
 ///

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -12,6 +12,7 @@ mod migrations;
 mod notifications;
 #[cfg(any(feature = "bb8", feature = "deadpool", feature = "mobc"))]
 mod pooling;
+mod run_query_dsl_impl_match;
 #[cfg(feature = "async-connection-wrapper")]
 mod sync_wrapper;
 mod transactions;

--- a/tests/run_query_dsl_impl_match.rs
+++ b/tests/run_query_dsl_impl_match.rs
@@ -1,0 +1,148 @@
+use super::{connection, users, User};
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+
+#[derive(Debug, QueryableByName, PartialEq)]
+struct CountType {
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    pub count: i64,
+}
+
+#[tokio::test]
+async fn test_boxed_sql() {
+    use diesel::query_builder::BoxedSqlQuery;
+
+    let mut con = connection().await;
+
+    let boxed: BoxedSqlQuery<_, _> =
+        diesel::sql_query("select count(*) as count from users").into_boxed();
+
+    let result = boxed.get_result::<CountType>(&mut con).await.unwrap();
+
+    assert_eq!(result.count, 0);
+}
+
+#[tokio::test]
+async fn test_select_statement() {
+    use diesel::query_builder::SelectStatement;
+
+    let mut con = connection().await;
+
+    let select: SelectStatement<_, _, _, _, _, _, _> = users::table.select(User::as_select());
+
+    let result = select.get_results(&mut con).await.unwrap();
+
+    assert_eq!(result.len(), 0);
+}
+
+#[tokio::test]
+async fn test_sql_query() {
+    use diesel::query_builder::SqlQuery;
+
+    let mut con = connection().await;
+
+    let sql: SqlQuery<_> = diesel::sql_query("select count(*) as count from users");
+
+    let result: CountType = sql.get_result(&mut con).await.unwrap();
+
+    assert_eq!(result.count, 0);
+}
+
+#[tokio::test]
+async fn test_unchecked_bind() {
+    use diesel::expression::UncheckedBind;
+    use diesel::sql_types::{BigInt, Text};
+
+    let mut con = connection().await;
+
+    let unchecked: UncheckedBind<_, _> =
+        diesel::dsl::sql::<BigInt>("SELECT count(id) FROM users WHERE name = ")
+            .bind::<Text, _>("Bob");
+
+    let result = unchecked.get_result(&mut con).await;
+
+    assert_eq!(Ok(0), result);
+}
+
+#[tokio::test]
+async fn test_alias() {
+    use diesel::query_source::Alias;
+
+    let mut con = connection().await;
+
+    let aliased: Alias<_> = diesel::alias!(users as other);
+
+    let result = aliased.get_results::<User>(&mut con).await.unwrap();
+
+    assert_eq!(result.len(), 0);
+}
+
+#[tokio::test]
+async fn test_boxed_select() {
+    use diesel::query_builder::BoxedSelectStatement;
+
+    let mut con = connection().await;
+
+    let select: BoxedSelectStatement<_, _, _, _> =
+        users::table.select(User::as_select()).into_boxed();
+
+    let result = select.get_results(&mut con).await.unwrap();
+
+    assert_eq!(result.len(), 0);
+}
+
+#[tokio::test]
+async fn test_sql_literal() {
+    use diesel::expression::SqlLiteral;
+    use diesel::sql_types::Integer;
+
+    let mut con = connection().await;
+
+    let literal: SqlLiteral<_> = diesel::dsl::sql::<Integer>("SELECT 6");
+
+    let result = literal.get_result(&mut con).await;
+
+    assert_eq!(Ok(6), result);
+}
+
+#[tokio::test]
+async fn test_delete() {
+    use diesel::query_builder::DeleteStatement;
+
+    let mut con = connection().await;
+
+    let delete: DeleteStatement<_, _, _> = diesel::delete(users::table);
+
+    let result = delete.execute(&mut con).await;
+
+    assert_eq!(Ok(0), result);
+}
+
+#[tokio::test]
+async fn test_insert_statement() {
+    use diesel::query_builder::InsertStatement;
+
+    let mut con = connection().await;
+
+    let inserted_names: InsertStatement<_, _, _, _> =
+        diesel::insert_into(users::table).values(users::name.eq("Timmy"));
+
+    let result = inserted_names.execute(&mut con).await;
+
+    assert_eq!(Ok(1), result);
+}
+
+#[tokio::test]
+async fn test_update_statement() {
+    use diesel::query_builder::UpdateStatement;
+
+    let mut con = connection().await;
+
+    let update: UpdateStatement<_, _, _, _> = diesel::update(users::table)
+        .set(users::name.eq("Jim"))
+        .filter(users::name.eq("Sean"));
+
+    let result = update.execute(&mut con).await;
+
+    assert_eq!(Ok(0), result);
+}


### PR DESCRIPTION
This resolves issue https://github.com/weiznich/diesel_async/issues/142 which stems from the async RunQueryDsl being implemented for ALL types.

In addition it adds some constraints that were missing from async LoadQuery when compared to diesel LoadQuery

Comparing the original diesel RunQueryDsl to the async one, the original only implements RunQueryDsl for types that implement Table and a few other explicitly tagged (like SqlQuery)

https://github.com/diesel-rs/diesel/blob/v2.2.7/diesel/src/query_dsl/mod.rs#L1785-L1791

the following shows how there is not an issue with diesel proper, only with diesel_async::RunQueryDsl

```rust
mod sub {

    pub(crate) struct A {
        pub(crate) items: Vec<String>,
    }
}

mod success_1 {
    fn test(value: super::sub::A) -> String {
        value.items.first().map(|s| s.into()).unwrap() // properly compiles and uses Vec::first
    }
}

mod success_2 {
    use diesel::prelude::*;
    fn test(value: super::sub::A) -> String {
        value.items.first().map(|s| s.into()).unwrap() // properly compiles and uses Vec::first
    }
}

mod failure {
    use diesel::prelude::*;
    use diesel_async::RunQueryDsl;

    fn test(value: super::sub::A) -> String {
        value.items.first().map(|s| s.into()).unwrap() // complains Table is not implemented by Vec<std::string::String>
    }
}
```