### PR TITLE
Bump minimal supported rust version to 1.84

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,11 +232,11 @@ jobs:
       - name: Check formating
         run: cargo +stable fmt --all -- --check
   minimal_rust_version:
-    name: Check Minimal supported rust version (1.82.0)
+    name: Check Minimal supported rust version (1.84.0)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.82.0
+      - uses: dtolnay/rust-toolchain@1.84.0
       - uses: dtolnay/rust-toolchain@nightly
       - uses: taiki-e/install-action@cargo-hack
       - uses: taiki-e/install-action@cargo-minimal-versions
@@ -245,4 +245,4 @@ jobs:
         # has broken min-version dependencies
         # cannot test sqlite yet as that crate
         # as broken min-version dependencies as well
-        run: cargo +1.82.0 minimal-versions check -p diesel-async --features "postgres bb8 deadpool mobc"
+        run: cargo +1.84.0 minimal-versions check -p diesel-async --features "postgres bb8 deadpool mobc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/weiznich/diesel_async"
 keywords = ["orm", "database", "sql", "async"]
 categories = ["database"]
 description = "An async extension for Diesel the safe, extensible ORM and Query Builder"
-rust-version = "1.82.0"
+rust-version = "1.84.0"
 
 [dependencies]
 futures-core = "0.3.17"


### PR DESCRIPTION
This commit bumps the minimal supported rust version to 1.84 to align with diesel's master branch.