### PR TITLE
Add AsyncConnectionWrapper::into_inner

### DIFF
--- a/src/async_connection_wrapper.rs
+++ b/src/async_connection_wrapper.rs
@@ -123,6 +123,17 @@ mod implementation {
         }
     }
 
+    impl<C, B> AsyncConnectionWrapper<C, B>
+    where
+        C: crate::AsyncConnection,
+    {
+        /// Consumes the [`AsyncConnectionWrapper`] returning the wrapped inner
+        /// [`AsyncConnection`].
+        pub fn into_inner(self) -> C {
+            self.inner
+        }
+    }
+
     impl<C, B> Deref for AsyncConnectionWrapper<C, B> {
         type Target = C;
 

--- a/tests/sync_wrapper.rs
+++ b/tests/sync_wrapper.rs
@@ -66,3 +66,30 @@ fn check_run_migration() {
     // just use `run_migrations` here because that's the easiest one without additional setup
     conn.run_migrations(&migrations).unwrap();
 }
+
+#[tokio::test]
+async fn test_sync_wrapper_unwrap() {
+    let db_url = std::env::var("DATABASE_URL").unwrap();
+
+    let conn = tokio::task::spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
+        let mut conn = AsyncConnectionWrapper::<crate::TestConnection>::establish(&db_url).unwrap();
+        let res =
+            diesel::select(1.into_sql::<diesel::sql_types::Integer>()).get_result::<i32>(&mut conn);
+        assert_eq!(Ok(1), res);
+        conn
+    })
+    .await
+    .unwrap();
+
+    {
+        use diesel_async::RunQueryDsl;
+
+        let mut conn = conn.into_inner();
+        let res = diesel::select(1.into_sql::<diesel::sql_types::Integer>())
+            .get_result::<i32>(&mut conn)
+            .await;
+        assert_eq!(Ok(1), res);
+    }
+}


### PR DESCRIPTION
Fixes #213.

Adds an method which enables reuse of a wrapped async connection.