### PR TITLE
Use default instrumentation in AsyncPgConnection::try_from_client_and_connection

### DIFF
--- a/src/pg/mod.rs
+++ b/src/pg/mod.rs
@@ -503,7 +503,9 @@ impl AsyncPgConnection {
             Some(error_rx),
             Some(notification_rx),
             Some(shutdown_tx),
-            Arc::new(std::sync::Mutex::new(DynInstrumentation::none())),
+            Arc::new(std::sync::Mutex::new(
+                DynInstrumentation::default_instrumentation(),
+            )),
         )
         .await
     }


### PR DESCRIPTION
Default instrumentation is used in `AsyncPgConnection::try_from`, but not in `AsyncPgConnection::try_from_client_and_connection`.