### PR TITLE
Add a cancellation token to AsyncMysqlConnection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ mod transaction_manager;
 pub use self::mysql::AsyncMysqlConnection;
 #[cfg(feature = "mysql")]
 #[doc(inline)]
-pub use self::mysql::CancelToken;
+pub use self::mysql::MysqlCancelToken;
 #[cfg(feature = "postgres")]
 #[doc(inline)]
 pub use self::pg::AsyncPgConnection;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,9 @@ mod transaction_manager;
 #[cfg(feature = "mysql")]
 #[doc(inline)]
 pub use self::mysql::AsyncMysqlConnection;
+#[cfg(feature = "mysql")]
+#[doc(inline)]
+pub use self::mysql::CancelToken;
 #[cfg(feature = "postgres")]
 #[doc(inline)]
 pub use self::pg::AsyncPgConnection;

--- a/src/mysql/cancel_token.rs
+++ b/src/mysql/cancel_token.rs
@@ -1,0 +1,37 @@
+use mysql_async::prelude::Query;
+use mysql_async::{Opts, OptsBuilder};
+
+use crate::mysql::error_helper::ErrorHelper;
+
+/// The capability to request cancellation of in-progress queries on a
+/// connection.
+#[derive(Clone)]
+pub struct CancelToken {
+    pub(crate) opts: Opts,
+    pub(crate) kill_id: u32,
+}
+
+impl CancelToken {
+    /// Attempts to cancel the in-progress query on the connection associated
+    /// with this `CancelToken`.
+    ///
+    /// The server provides no information about whether a cancellation attempt was successful or not. An error will
+    /// only be returned if the client was unable to connect to the database.
+    ///
+    /// Cancellation is inherently racy. There is no guarantee that the
+    /// cancellation request will reach the server before the query terminates
+    /// normally, or that the connection associated with this token is still
+    /// active.
+    pub async fn cancel_query(&self) -> Result<(), diesel::result::ConnectionError> {
+        let builder = OptsBuilder::from_opts(self.opts.clone());
+
+        let conn = mysql_async::Conn::new(builder).await.map_err(ErrorHelper)?;
+
+        format!("KILL QUERY {};", self.kill_id)
+            .ignore(conn)
+            .await
+            .map_err(ErrorHelper)?;
+
+        Ok(())
+    }
+}

--- a/src/mysql/cancel_token.rs
+++ b/src/mysql/cancel_token.rs
@@ -6,12 +6,12 @@ use crate::mysql::error_helper::ErrorHelper;
 /// The capability to request cancellation of in-progress queries on a
 /// connection.
 #[derive(Clone)]
-pub struct CancelToken {
+pub struct MysqlCancelToken {
     pub(crate) opts: Opts,
     pub(crate) kill_id: u32,
 }
 
-impl CancelToken {
+impl MysqlCancelToken {
     /// Attempts to cancel the in-progress query on the connection associated
     /// with this `CancelToken`.
     ///
@@ -22,7 +22,7 @@ impl CancelToken {
     /// cancellation request will reach the server before the query terminates
     /// normally, or that the connection associated with this token is still
     /// active.
-    pub async fn cancel_query(&self) -> Result<(), diesel::result::ConnectionError> {
+    pub async fn cancel_query(&self) -> diesel::result::ConnectionResult<()> {
         let builder = OptsBuilder::from_opts(self.opts.clone());
 
         let conn = mysql_async::Conn::new(builder).await.map_err(ErrorHelper)?;

--- a/src/mysql/mod.rs
+++ b/src/mysql/mod.rs
@@ -24,7 +24,7 @@ mod error_helper;
 mod row;
 mod serialize;
 
-pub use self::cancel_token::CancelToken;
+pub use self::cancel_token::MysqlCancelToken;
 use self::error_helper::ErrorHelper;
 use self::row::MysqlRow;
 use self::serialize::ToSqlHelper;
@@ -257,11 +257,11 @@ impl AsyncMysqlConnection {
     }
 
     /// Constructs a cancellation token that can later be used to request cancellation of a query running on the connection associated with this client.
-    pub fn cancel_token(&self) -> CancelToken {
+    pub fn cancel_token(&self) -> MysqlCancelToken {
         let kill_id = self.conn.id();
         let opts = self.conn.opts().clone();
 
-        CancelToken { kill_id, opts }
+        MysqlCancelToken { kill_id, opts }
     }
 
     fn with_prepared_statement<'conn, T, F, R>(

--- a/src/mysql/mod.rs
+++ b/src/mysql/mod.rs
@@ -19,10 +19,12 @@ use mysql_async::prelude::Queryable;
 use mysql_async::{Opts, OptsBuilder, Statement};
 use std::future::Future;
 
+mod cancel_token;
 mod error_helper;
 mod row;
 mod serialize;
 
+pub use self::cancel_token::CancelToken;
 use self::error_helper::ErrorHelper;
 use self::row::MysqlRow;
 use self::serialize::ToSqlHelper;
@@ -252,6 +254,14 @@ impl AsyncMysqlConnection {
         }
 
         Ok(conn)
+    }
+
+    /// Constructs a cancellation token that can later be used to request cancellation of a query running on the connection associated with this client.
+    pub fn cancel_token(&self) -> CancelToken {
+        let kill_id = self.conn.id();
+        let opts = self.conn.opts().clone();
+
+        CancelToken { kill_id, opts }
     }
 
     fn with_prepared_statement<'conn, T, F, R>(

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -207,7 +207,7 @@ async fn mysql_cancel_token() {
         },
         Ok(r) => match r[0] {
             1 => {}
-            _ => panic!(""),
+            _ => panic!("query completed successfully without cancellation"),
         },
     }
 }


### PR DESCRIPTION
After this discussion ([#4587](https://github.com/diesel-rs/diesel/discussions/4587) ) in the spring, I decided to go ahead and build a MySQL cancel token according to the basic design discussed. I hope taking a stab at this and opening a PR right away isn't premature or inappropriate.

I added some basic documentation and a test, although the test is a bit awkward: MySQL wouldn't reliably return an error for me when a query was cancelled, so I had to fall back to using the load method and checking the return integer. Also, I wasn't able to move an AsyncMysqlConnection between threads so I had it send the cancel token via a channel.

Let me know if there are any changes I should make or if I'm out of line here.