### PR TITLE
Add support for running migrations via `diesel_migrations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## [Unreleased]
 
+* Added support for running migrations via `AsyncMigrationHarness`
+
 ## [0.6.1] - 2025-07-03
 
 * Fix features for some dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,10 @@ features = [
   "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
 ]
 
+[dependencies.diesel_migrations]
+version = "~2.3.0"
+optional = true
+
 [dev-dependencies]
 tokio = { version = "1.12.0", features = ["rt", "macros", "rt-multi-thread"] }
 cfg-if = "1"
@@ -61,7 +65,7 @@ features = [
 version = "2.3.0"
 
 [features]
-default = []
+default = ["migrations"]
 mysql = [
   "diesel/mysql_backend",
   "mysql_async",
@@ -73,6 +77,7 @@ postgres = ["diesel/postgres_backend", "tokio-postgres", "tokio", "tokio/rt"]
 sqlite = ["diesel/sqlite", "sync-connection-wrapper"]
 sync-connection-wrapper = ["tokio/rt"]
 async-connection-wrapper = ["tokio/net", "tokio/rt"]
+migrations = ["diesel_migrations", "async-connection-wrapper", "tokio/rt-multi-thread"]
 pool = []
 r2d2 = ["pool", "diesel/r2d2"]
 bb8 = ["pool", "dep:bb8"]
@@ -95,10 +100,12 @@ features = [
   "async-connection-wrapper",
   "sync-connection-wrapper",
   "r2d2",
+  "migrations",
+  "tokio/macros",
 ]
 no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", " -Z", "unstable-options", "--generate-link-to-definition"]
 
 [workspace]
 members = [

--- a/examples/postgres/run-pending-migrations-with-rustls/Cargo.toml
+++ b/examples/postgres/run-pending-migrations-with-rustls/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-diesel-async = { version = "0.6.0", path = "../../../", features = ["bb8", "postgres", "async-connection-wrapper"] }
+diesel-async = { version = "0.6.0", path = "../../../", features = ["bb8", "postgres", "migrations"] }
 futures-util = "0.3.21"
 rustls = "0.23.8"
 rustls-platform-verifier = "0.5.0"

--- a/src/async_connection_wrapper.rs
+++ b/src/async_connection_wrapper.rs
@@ -99,7 +99,7 @@ pub type AsyncConnectionWrapper<C, B = self::implementation::Tokio> =
 #[cfg(not(feature = "tokio"))]
 pub use self::implementation::AsyncConnectionWrapper;
 
-mod implementation {
+pub(crate) mod implementation {
     use diesel::connection::{CacheSize, Instrumentation, SimpleConnection};
     use std::ops::{Deref, DerefMut};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,11 +6,11 @@
 //! that perform actual io-work.
 //! This includes async counterparts the following traits:
 //! * [`diesel::prelude::RunQueryDsl`](https://docs.diesel.rs/2.0.x/diesel/prelude/trait.RunQueryDsl.html)
-//!    -> [`diesel_async::RunQueryDsl`](crate::RunQueryDsl)
+//!   -> [`diesel_async::RunQueryDsl`](crate::RunQueryDsl)
 //! * [`diesel::connection::Connection`](https://docs.diesel.rs/2.0.x/diesel/connection/trait.Connection.html)
-//!    -> [`diesel_async::AsyncConnection`](crate::AsyncConnection)
+//!   -> [`diesel_async::AsyncConnection`](crate::AsyncConnection)
 //! * [`diesel::query_dsl::UpdateAndFetchResults`](https://docs.diesel.rs/2.0.x/diesel/query_dsl/trait.UpdateAndFetchResults.html)
-//!    -> [`diesel_async::UpdateAndFetchResults`](crate::UpdateAndFetchResults)
+//!   -> [`diesel_async::UpdateAndFetchResults`](crate::UpdateAndFetchResults)
 //!
 //! These traits closely mirror their diesel counter parts while providing async functionality.
 //!
@@ -65,6 +65,26 @@
 //! #     Ok(())
 //! # }
 //! ```
+//!
+//! ## Crate features:
+//!
+//! * `postgres`: Enables the [`AsyncPgConnection`] implementation
+//! * `mysql`: Enables the [`AsyncMysqlConnection`] implementation
+//! * `sqlite`: Enables the [`SyncConnectionWrapper`](crate::sync_connection_wrapper::SyncConnectionWrapper)
+//!   and everything required to work with SQLite
+//! * `sync-connection-wrapper`: Enables the
+//!   [`SyncConnectionWrapper`](crate::sync_connection_wrapper::SyncConnectionWrapper) which allows to
+//!   wrap sync connections from [`diesel`] into async connection wrapper
+//! * `async-connection-wrapper`: Enables the [`AsyncConnectionWrapper`](crate::async_connection_wrapper::AsyncConnectionWrapper)
+//!   which allows
+//!   to use connection implementations from this crate as sync [`diesel::Connection`]
+//! * `migrations`: Enables the [`AsyncMigrationHarness`] to execute migrations via
+//!   [`diesel_migrations`]
+//! * `pool`: Enables general support for connection pools
+//! * `r2d2`: Enables support for pooling via the [`r2d2`] crate
+//! * `bb8`: Enables support for pooling via the [`bb8`] crate
+//! * `mobc`: Enables support for pooling via the [`mobc`] crate
+//! * `deadpool`: Enables support for pooling via the [`deadpool`] crate
 
 #![warn(
     missing_docs,
@@ -89,6 +109,8 @@ use scoped_futures::{ScopedBoxFuture, ScopedFutureExt};
 
 #[cfg(feature = "async-connection-wrapper")]
 pub mod async_connection_wrapper;
+#[cfg(feature = "migrations")]
+mod migrations;
 #[cfg(feature = "mysql")]
 mod mysql;
 #[cfg(feature = "postgres")]
@@ -111,6 +133,9 @@ pub use self::pg::AsyncPgConnection;
 #[doc(inline)]
 pub use self::run_query_dsl::*;
 
+#[doc(inline)]
+#[cfg(feature = "migrations")]
+pub use self::migrations::AsyncMigrationHarness;
 #[doc(inline)]
 pub use self::transaction_manager::{AnsiTransactionManager, TransactionManager};
 

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -1,0 +1,159 @@
+use diesel::migration::{Migration, MigrationVersion, Result};
+
+use crate::async_connection_wrapper::AsyncConnectionWrapper;
+use crate::AsyncConnection;
+
+/// A diesel-migration [`MigrationHarness`](diesel_migrations::MigrationHarness) to run migrations
+/// via an [`AsyncConnection`](crate::AsyncConnection)
+///
+/// ## Example
+///
+/// ```no_run
+/// # include!("doctest_setup.rs");
+/// # async fn run_test() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>{
+///       use diesel_async::AsyncMigrationHarness;
+///       use diesel_migrations::{FileBasedMigrations, MigrationHarness};
+///
+///       let mut connection = connection_no_data().await;
+///
+///       // Alternativly use `diesel_migrations::embed_migrations!()`
+///       // to get a list of migrations
+///       let migrations = FileBasedMigrations::find_migrations_directory()?;
+///
+///       let mut harness = AsyncMigrationHarness::new(connection);
+///       harness.run_pending_migrations(migrations)?;
+///       // get back the connection from the harness
+///       let connection = harness.into_inner();
+///       Ok(())
+/// # }
+/// # #[tokio::main]
+/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+/// #     run_test().await?;
+/// #     Ok(())
+/// # }
+/// ```
+///
+/// ## Example with pool
+///
+/// ```no_run
+/// # include!("doctest_setup.rs");
+/// # #[cfg(feature = "deadpool")]
+/// # use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+/// #
+/// # #[cfg(all(feature = "postgres", feature = "deadpool"))]
+/// # fn get_config() -> AsyncDieselConnectionManager<diesel_async::AsyncPgConnection> {
+/// #     let db_url = database_url_from_env("PG_DATABASE_URL");
+/// let config = AsyncDieselConnectionManager::<diesel_async::AsyncPgConnection>::new(db_url);
+/// #     config
+/// #  }
+/// #
+/// # #[cfg(all(feature = "mysql", feature = "deadpool"))]
+/// # fn get_config() -> AsyncDieselConnectionManager<diesel_async::AsyncMysqlConnection> {
+/// #     let db_url = database_url_from_env("MYSQL_DATABASE_URL");
+/// #    let config = AsyncDieselConnectionManager::<diesel_async::AsyncMysqlConnection>::new(db_url);
+/// #     config
+/// #  }
+/// #
+/// # #[cfg(all(feature = "sqlite", feature = "deadpool"))]
+/// # fn get_config() -> AsyncDieselConnectionManager<diesel_async::sync_connection_wrapper::SyncConnectionWrapper<diesel::SqliteConnection>> {
+/// #     let db_url = database_url_from_env("SQLITE_DATABASE_URL");
+/// #     let config = AsyncDieselConnectionManager::<diesel_async::sync_connection_wrapper::SyncConnectionWrapper<diesel::SqliteConnection>>::new(db_url);
+/// #     config
+/// # }
+/// # #[cfg(feature = "deadpool")]
+/// # async fn run_test() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>{
+///       use diesel_async::pooled_connection::deadpool::Pool;
+///       use diesel_async::AsyncMigrationHarness;
+///       use diesel_migrations::{FileBasedMigrations, MigrationHarness};
+///
+///       // Alternativly use `diesel_migrations::embed_migrations!()`
+///       // to get a list of migrations
+///       let migrations = FileBasedMigrations::find_migrations_directory()?;
+///
+///       let pool = Pool::builder(get_config()).build()?;
+///       let mut harness = AsyncMigrationHarness::new(pool.get().await?);
+///       harness.run_pending_migrations(migrations)?;
+///       Ok(())
+/// # }
+///
+/// # #[cfg(not(feature = "deadpool"))]
+/// # async fn run_test() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
+/// # {
+/// #   Ok(())
+/// # }
+/// #
+/// # #[tokio::main]
+/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+/// #     run_test().await?;
+/// #     Ok(())
+/// # }
+/// ```
+///
+/// Internally this harness is using [`tokio::task::block_in_place`] and [`AsyncConnectionWrapper`]
+/// to utilize sync Diesel's migration infrastructure. For most applications this shouldn't
+/// be problematic as migrations are usually run at application startup and most applications
+/// default to use the multithreaded tokio runtime. In turn this also means that you cannot use
+/// this migration harness if you use the current thread variant of the tokio runtime or if
+/// you run migrations in a very special setup (e.g by using [`tokio::select!`] or [`tokio::join!`]
+/// on a future produced by running the migrations). Consider manually construct a blocking task via
+/// [`tokio::task::spawn_blocking`] instead.
+pub struct AsyncMigrationHarness<C> {
+    conn: AsyncConnectionWrapper<C, crate::async_connection_wrapper::implementation::Tokio>,
+}
+
+impl<C> AsyncMigrationHarness<C>
+where
+    C: AsyncConnection,
+{
+    /// Construct a new `AsyncMigrationHarness` from a given connection
+    pub fn new(connection: C) -> Self {
+        Self {
+            conn: AsyncConnectionWrapper::from(connection),
+        }
+    }
+
+    /// Return the connection stored inside this instance of `AsyncMigrationHarness`
+    pub fn into_inner(self) -> C {
+        self.conn.into_inner()
+    }
+}
+
+impl<C> From<C> for AsyncMigrationHarness<C>
+where
+    C: AsyncConnection,
+{
+    fn from(value: C) -> Self {
+        AsyncMigrationHarness::new(value)
+    }
+}
+
+impl<C> diesel_migrations::MigrationHarness<C::Backend> for AsyncMigrationHarness<C>
+where
+    C: AsyncConnection,
+    AsyncConnectionWrapper<C, crate::async_connection_wrapper::implementation::Tokio>:
+        diesel::Connection<Backend = C::Backend> + diesel_migrations::MigrationHarness<C::Backend>,
+{
+    fn run_migration(
+        &mut self,
+        migration: &dyn Migration<C::Backend>,
+    ) -> Result<MigrationVersion<'static>> {
+        tokio::task::block_in_place(|| {
+            diesel_migrations::MigrationHarness::run_migration(&mut self.conn, migration)
+        })
+    }
+
+    fn revert_migration(
+        &mut self,
+        migration: &dyn Migration<C::Backend>,
+    ) -> Result<MigrationVersion<'static>> {
+        tokio::task::block_in_place(|| {
+            diesel_migrations::MigrationHarness::revert_migration(&mut self.conn, migration)
+        })
+    }
+
+    fn applied_migrations(&mut self) -> Result<Vec<MigrationVersion<'static>>> {
+        tokio::task::block_in_place(|| {
+            diesel_migrations::MigrationHarness::applied_migrations(&mut self.conn)
+        })
+    }
+}

--- a/src/pooled_connection/mod.rs
+++ b/src/pooled_connection/mod.rs
@@ -214,6 +214,7 @@ where
     }
 }
 
+#[diagnostic::do_not_recommend]
 impl<C> AsyncConnection for C
 where
     C: DerefMut + Send,

--- a/tests/instrumentation.rs
+++ b/tests/instrumentation.rs
@@ -99,7 +99,7 @@ async fn check_events_are_emitted_for_execute_returning_count() {
         .await
         .unwrap();
     let events = events_to_check.lock().unwrap();
-    assert_eq!(events.len(), 3, "{:?}", events);
+    assert_eq!(events.len(), 3, "{events:?}");
     assert_matches!(events[0], Event::StartQuery { .. });
     assert_matches!(events[1], Event::CacheQuery { .. });
     assert_matches!(events[2], Event::FinishQuery { .. });
@@ -112,7 +112,7 @@ async fn check_events_are_emitted_for_load() {
         .await
         .unwrap();
     let events = events_to_check.lock().unwrap();
-    assert_eq!(events.len(), 3, "{:?}", events);
+    assert_eq!(events.len(), 3, "{events:?}");
     assert_matches!(events[0], Event::StartQuery { .. });
     assert_matches!(events[1], Event::CacheQuery { .. });
     assert_matches!(events[2], Event::FinishQuery { .. });
@@ -126,7 +126,7 @@ async fn check_events_are_emitted_for_execute_returning_count_does_not_contain_c
         .await
         .unwrap();
     let events = events_to_check.lock().unwrap();
-    assert_eq!(events.len(), 2, "{:?}", events);
+    assert_eq!(events.len(), 2, "{events:?}");
     assert_matches!(events[0], Event::StartQuery { .. });
     assert_matches!(events[1], Event::FinishQuery { .. });
 }
@@ -138,7 +138,7 @@ async fn check_events_are_emitted_for_load_does_not_contain_cache_for_uncached_q
         .await
         .unwrap();
     let events = events_to_check.lock().unwrap();
-    assert_eq!(events.len(), 2, "{:?}", events);
+    assert_eq!(events.len(), 2, "{events:?}");
     assert_matches!(events[0], Event::StartQuery { .. });
     assert_matches!(events[1], Event::FinishQuery { .. });
 }
@@ -150,7 +150,7 @@ async fn check_events_are_emitted_for_execute_returning_count_does_contain_error
         .execute_returning_count(diesel::sql_query("invalid"))
         .await;
     let events = events_to_check.lock().unwrap();
-    assert_eq!(events.len(), 2, "{:?}", events);
+    assert_eq!(events.len(), 2, "{events:?}");
     assert_matches!(events[0], Event::StartQuery { .. });
     assert_matches!(events[1], Event::FinishQuery { error: Some(_), .. });
 }
@@ -160,7 +160,7 @@ async fn check_events_are_emitted_for_load_does_contain_error_for_failures() {
     let (events_to_check, mut conn) = setup_test_case().await;
     let _ = AsyncConnectionCore::load(&mut conn, diesel::sql_query("invalid")).await;
     let events = events_to_check.lock().unwrap();
-    assert_eq!(events.len(), 2, "{:?}", events);
+    assert_eq!(events.len(), 2, "{events:?}");
     assert_matches!(events[0], Event::StartQuery { .. });
     assert_matches!(events[1], Event::FinishQuery { error: Some(_), .. });
 }
@@ -175,7 +175,7 @@ async fn check_events_are_emitted_for_execute_returning_count_repeat_does_not_re
         .await
         .unwrap();
     let events = events_to_check.lock().unwrap();
-    assert_eq!(events.len(), 5, "{:?}", events);
+    assert_eq!(events.len(), 5, "{events:?}");
     assert_matches!(events[0], Event::StartQuery { .. });
     assert_matches!(events[1], Event::CacheQuery { .. });
     assert_matches!(events[2], Event::FinishQuery { .. });
@@ -193,7 +193,7 @@ async fn check_events_are_emitted_for_load_repeat_does_not_repeat_cache() {
         .await
         .unwrap();
     let events = events_to_check.lock().unwrap();
-    assert_eq!(events.len(), 5, "{:?}", events);
+    assert_eq!(events.len(), 5, "{events:?}");
     assert_matches!(events[0], Event::StartQuery { .. });
     assert_matches!(events[1], Event::CacheQuery { .. });
     assert_matches!(events[2], Event::FinishQuery { .. });
@@ -208,7 +208,7 @@ async fn check_events_transaction() {
         .await
         .unwrap();
     let events = events_to_check.lock().unwrap();
-    assert_eq!(events.len(), 6, "{:?}", events);
+    assert_eq!(events.len(), 6, "{events:?}");
     assert_matches!(events[0], Event::BeginTransaction { .. });
     assert_matches!(events[1], Event::StartQuery { .. });
     assert_matches!(events[2], Event::FinishQuery { .. });
@@ -226,7 +226,7 @@ async fn check_events_transaction_error() {
         })
         .await;
     let events = events_to_check.lock().unwrap();
-    assert_eq!(events.len(), 6, "{:?}", events);
+    assert_eq!(events.len(), 6, "{events:?}");
     assert_matches!(events[0], Event::BeginTransaction { .. });
     assert_matches!(events[1], Event::StartQuery { .. });
     assert_matches!(events[2], Event::FinishQuery { .. });
@@ -247,7 +247,7 @@ async fn check_events_transaction_nested() {
     .await
     .unwrap();
     let events = events_to_check.lock().unwrap();
-    assert_eq!(events.len(), 12, "{:?}", events);
+    assert_eq!(events.len(), 12, "{events:?}");
     assert_matches!(events[0], Event::BeginTransaction { .. });
     assert_matches!(events[1], Event::StartQuery { .. });
     assert_matches!(events[2], Event::FinishQuery { .. });
@@ -276,7 +276,7 @@ async fn check_events_transaction_builder() {
         .await
         .unwrap();
     let events = events_to_check.lock().unwrap();
-    assert_eq!(events.len(), 6, "{:?}", events);
+    assert_eq!(events.len(), 6, "{events:?}");
     assert_matches!(events[0], Event::BeginTransaction { .. });
     assert_matches!(events[1], Event::StartQuery { .. });
     assert_matches!(events[2], Event::FinishQuery { .. });

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -7,6 +7,8 @@ use std::fmt::Debug;
 #[cfg(feature = "postgres")]
 mod custom_types;
 mod instrumentation;
+#[cfg(feature = "migrations")]
+mod migrations;
 mod notifications;
 #[cfg(any(feature = "bb8", feature = "deadpool", feature = "mobc"))]
 mod pooling;
@@ -161,7 +163,7 @@ async fn postgres_cancel_token() {
     match err {
         Error::DatabaseError(DatabaseErrorKind::Unknown, v)
             if v.message() == "canceling statement due to user request" => {}
-        _ => panic!("unexpected error: {:?}", err),
+        _ => panic!("unexpected error: {err:?}"),
     }
 }
 

--- a/tests/migrations.rs
+++ b/tests/migrations.rs
@@ -1,0 +1,27 @@
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::AsyncMigrationHarness;
+use diesel_migrations::MigrationHarness;
+
+// These two tests are mostly smoke tests to verify
+// that the `AsyncMigrationHarness` actually implements
+// the necessary traits
+
+#[tokio::test(flavor = "multi_thread")]
+async fn plain_connection() {
+    let conn = super::connection().await;
+    let mut harness = AsyncMigrationHarness::from(conn);
+    harness.applied_migrations().unwrap();
+}
+
+#[cfg(feature = "deadpool")]
+#[tokio::test(flavor = "multi_thread")]
+async fn pool_connection() {
+    use diesel_async::pooled_connection::deadpool::Pool;
+
+    let db_url = std::env::var("DATABASE_URL").unwrap();
+    let config = AsyncDieselConnectionManager::<super::TestConnection>::new(db_url);
+    let pool = Pool::builder(config).build().unwrap();
+    let conn = pool.get().await.unwrap();
+    let mut harness = AsyncMigrationHarness::from(conn);
+    harness.applied_migrations().unwrap();
+}


### PR DESCRIPTION
This commit provides an `AsyncMigrationHarness` which enables running migrations via `diesel_migrations` with any `AsyncConnection`

This commit also provides some additional documenation and other minor fixes.