### PR TITLE
Use custom `Future` combinators to avoid GAT errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ deadpool = { version = "0.12", optional = true, default-features = false, featur
 ] }
 mobc = { version = ">=0.7,<0.10", optional = true }
 scoped-futures = { version = "0.1", features = ["std"] }
-pin-project-lite = "0.2.16"
 
 [dependencies.diesel]
 version = "~2.3.0"

--- a/src/pg/mod.rs
+++ b/src/pg/mod.rs
@@ -1175,14 +1175,14 @@ mod tests {
 
         async fn fn37(
             mut conn: &AsyncPgConnection,
-        ) -> QueryResult<(usize, Vec<i32>, i32, Vec<i32>, i32)> {
+        ) -> QueryResult<(usize, (Vec<i32>, (i32, (Vec<i32>, i32))))> {
             let f3 = diesel::select(0_i32.into_sql::<Integer>()).execute(&mut conn);
             let f4 = diesel::select(4_i32.into_sql::<Integer>()).load::<i32>(&mut conn);
             let f5 = diesel::select(5_i32.into_sql::<Integer>()).get_result::<i32>(&mut conn);
             let f6 = diesel::select(6_i32.into_sql::<Integer>()).get_results::<i32>(&mut conn);
             let f7 = diesel::select(7_i32.into_sql::<Integer>()).first::<i32>(&mut conn);
 
-            try_join!(f3, f4, f5, f6, f7)
+            try_join(f3, try_join(f4, try_join(f5, try_join(f6, f7)))).await
         }
 
         conn.transaction(|conn| {
@@ -1190,7 +1190,7 @@ mod tests {
                 let f12 = fn12(conn);
                 let f37 = fn37(conn);
 
-                let ((r1, r2), (r3, r4, r5, r6, r7)) = try_join!(f12, f37).unwrap();
+                let ((r1, r2), (r3, (r4, (r5, (r6, r7))))) = try_join(f12, f37).await.unwrap();
 
                 assert_eq!(r1, 1);
                 assert_eq!(r2, 2);


### PR DESCRIPTION
Fixes https://github.com/weiznich/diesel_async/issues/249.

The compilation errors were caused by the lifetimes when using closures with `Future` combinators in the `RunQueryDsl` trait.
This PR fixes the GAT errors by redefining custom `Future` combinators to limit closure usage.