### PR TITLE
Fix docs.rs build by avoiding `--cfg docsrs` in rustc flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,6 @@ features = [
   "tokio/macros",
 ]
 no-default-features = true
-rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs", "-Z", "unstable-options", "--generate-link-to-definition"]
 
 [workspace]


### PR DESCRIPTION
This should fix the docs.rs breakage for real. Reason: https://bsky.app/profile/paolobarbolini.bsky.social/post/3m2gqwacksc2g

```bash
# works
RUSTDOCFLAGS="--cfg docsrs" cargo doc --all-features --no-deps

# breaks
RUSTFLAGS="--cfg docsrs" RUSTDOCFLAGS="--cfg docsrs" cargo doc --all-features --no-deps
```