### PR TITLE
Keep track of mysql statements to close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## [Unreleased]
 
+## [0.7.4] - 2025-11-07
+
+* Fixed an issue with dropping uncached mysql statements
+
 ## [0.7.3] - 2025-10-05
 
 * Another docs.rs build fix

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel-async"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Georg Semmler <github@weiznich.de>"]
 edition = "2021"
 autotests = false


### PR DESCRIPTION
This change refactors how we close uncached mysql statements. Instead of trying to issue the close request as part of the same SQL query, we now just keep track of whether a statement need to be closed or not and execute the closing as first operation in the next query execution. The large advantage of this approach is that we sidestep any async drop/cancelation related problems. The disadvantage is that we keep that statement open for a bit longer. I cannot see how we ever would have more than one statement in there per connection and we also keep the cached statements around, so this shouldn't cause any problems in practice.

Fix #269
Closes #270 

cc @lukezbihlyj I think this is a better solution than polling the whole stream for all backends