### PR TITLE
Implement UpdateAndFetchResults for SyncConnectionWrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## [Unreleased]
 
+* Added support for UpdateAndFetchResults for `SyncConnectionWrapper`, allowing to use `save_changes`
+
 ## [0.7.4] - 2025-11-07
 
 * Fixed an issue with dropping uncached mysql statements


### PR DESCRIPTION
As discussed in https://github.com/weiznich/diesel_async/discussions/276

I made the impl generic over Connection and Backend, despite there only being one valid combination right now.

I tested it on my app, and with this patch I can now use `save_changes`.

I did want to add tests, but I didn't see any using the `SyncConnectionWrapper` or `sqlite`.

I could add it to the examples, if they are checked in CI?