### PR TITLE
Use real async closures for transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## [Unreleased]
 
+* Change all transaction related functions to accept an real async closure instead of 
+  the scoped boxed variant. This change requires adujsting all call sides of transaction 
+  based functions from `conn.transaction(|conn| async move {/* your code */}.scoped_boxed())`
+  to `conn.transaction(async |conn| /* your code */)`
+
 ## [0.8.0] - 2026-03-20
 
 * Added support for UpdateAndFetchResults for `SyncConnectionWrapper`, allowing to use `save_changes`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ deadpool = { version = "0.13", optional = true, default-features = false, featur
   "managed",
 ] }
 mobc = { version = ">=0.7,<0.10", optional = true }
-scoped-futures = { version = "0.1", features = ["std"] }
 pin-project-lite = "0.2.17"
 
 [dependencies.diesel]

--- a/examples/sync-wrapper/src/main.rs
+++ b/examples/sync-wrapper/src/main.rs
@@ -53,17 +53,15 @@ async fn transaction(
     new_name: &str,
 ) -> Result<Vec<User>, diesel::result::Error> {
     async_conn
-        .transaction::<Vec<User>, diesel::result::Error, _>(|c| {
-            Box::pin(async {
-                if old_name.is_empty() {
-                    Ok(Vec::new())
-                } else {
-                    diesel::update(users::table.filter(users::name.eq(old_name)))
-                        .set(users::name.eq(new_name))
-                        .load(c)
-                        .await
-                }
-            })
+        .transaction::<Vec<User>, diesel::result::Error, _>(async |c| {
+            if old_name.is_empty() {
+                Ok(Vec::new())
+            } else {
+                diesel::update(users::table.filter(users::name.eq(old_name)))
+                    .set(users::name.eq(new_name))
+                    .load(c)
+                    .await
+            }
         })
         .await
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,14 +98,11 @@ use diesel::connection::{CacheSize, Instrumentation};
 use diesel::query_builder::{AsQuery, QueryFragment, QueryId};
 use diesel::row::Row;
 use diesel::{ConnectionResult, QueryResult};
-use futures_core::future::BoxFuture;
 use futures_core::Stream;
 use futures_util::FutureExt;
 use std::fmt::Debug;
 use std::future::Future;
-
-pub use scoped_futures;
-use scoped_futures::{ScopedBoxFuture, ScopedFutureExt};
+use transaction_manager::AsyncFunc;
 
 #[cfg(feature = "async-connection-wrapper")]
 pub mod async_connection_wrapper;
@@ -244,7 +241,6 @@ pub trait AsyncConnection: AsyncConnectionCore + Sized {
     /// ```rust
     /// # include!("doctest_setup.rs");
     /// use diesel::result::Error;
-    /// use scoped_futures::ScopedFutureExt;
     /// use diesel_async::{RunQueryDsl, AsyncConnection};
     ///
     /// # #[tokio::main(flavor = "current_thread")]
@@ -255,7 +251,7 @@ pub trait AsyncConnection: AsyncConnectionCore + Sized {
     /// # async fn run_test() -> QueryResult<()> {
     /// #     use schema::users::dsl::*;
     /// #     let conn = &mut establish_connection().await;
-    /// conn.transaction::<_, Error, _>(|conn| async move {
+    /// conn.transaction::<_, Error, _>(async |conn| {
     ///     diesel::insert_into(users)
     ///         .values(name.eq("Ruby"))
     ///         .execute(conn)
@@ -265,9 +261,9 @@ pub trait AsyncConnection: AsyncConnectionCore + Sized {
     ///     assert_eq!(vec!["Sean", "Tess", "Ruby"], all_names);
     ///
     ///     Ok(())
-    /// }.scope_boxed()).await?;
+    /// }).await?;
     ///
-    /// conn.transaction::<(), _, _>(|conn| async move {
+    /// conn.transaction::<(), _, _>(async |conn| {
     ///     diesel::insert_into(users)
     ///         .values(name.eq("Pascal"))
     ///         .execute(conn)
@@ -279,7 +275,7 @@ pub trait AsyncConnection: AsyncConnectionCore + Sized {
     ///     // If we want to roll back the transaction, but don't have an
     ///     // actual error to return, we can return `RollbackTransaction`.
     ///     Err(Error::RollbackTransaction)
-    /// }.scope_boxed()).await;
+    /// }).await;
     ///
     /// let all_names = users.select(name).load::<String>(conn).await?;
     /// assert_eq!(vec!["Sean", "Tess", "Ruby"], all_names);
@@ -289,17 +285,17 @@ pub trait AsyncConnection: AsyncConnectionCore + Sized {
     fn transaction<'a, 'conn, R, E, F>(
         &'conn mut self,
         callback: F,
-    ) -> BoxFuture<'conn, Result<R, E>>
-    // we cannot use `impl Trait` here due to bugs in rustc
-    // https://github.com/rust-lang/rust/issues/100013
-    //impl Future<Output = Result<R, E>> + Send + 'async_trait
+    ) -> impl Future<Output = Result<R, E>> + Send + 'conn
     where
-        F: for<'r> FnOnce(&'r mut Self) -> ScopedBoxFuture<'a, 'r, Result<R, E>> + Send + 'a,
+        for<'r> F: AsyncFnOnce(&'r mut Self) -> Result<R, E>
+            + AsyncFunc<&'r mut Self, Result<R, E>, Fut: Send>
+            + Send
+            + 'a,
         E: From<diesel::result::Error> + Send + 'a,
         R: Send + 'a,
         'a: 'conn,
     {
-        Self::TransactionManager::transaction(self, callback).boxed()
+        Self::TransactionManager::transaction(self, callback)
     }
 
     /// Creates a transaction that will never be committed. This is useful for
@@ -334,7 +330,6 @@ pub trait AsyncConnection: AsyncConnectionCore + Sized {
     /// ```rust
     /// # include!("doctest_setup.rs");
     /// use diesel::result::Error;
-    /// use scoped_futures::ScopedFutureExt;
     /// use diesel_async::{RunQueryDsl, AsyncConnection};
     ///
     /// # #[tokio::main(flavor = "current_thread")]
@@ -345,7 +340,7 @@ pub trait AsyncConnection: AsyncConnectionCore + Sized {
     /// # async fn run_test() -> QueryResult<()> {
     /// #     use schema::users::dsl::*;
     /// #     let conn = &mut establish_connection().await;
-    /// conn.test_transaction::<_, Error, _>(|conn| async move {
+    /// conn.test_transaction::<_, Error, _>(async |conn| {
     ///     diesel::insert_into(users)
     ///         .values(name.eq("Ruby"))
     ///         .execute(conn)
@@ -355,7 +350,7 @@ pub trait AsyncConnection: AsyncConnectionCore + Sized {
     ///     assert_eq!(vec!["Sean", "Tess", "Ruby"], all_names);
     ///
     ///     Ok(())
-    /// }.scope_boxed()).await;
+    /// }).await;
     ///
     /// // Even though we returned `Ok`, the transaction wasn't committed.
     /// let all_names = users.select(name).load::<String>(conn).await?;
@@ -368,21 +363,24 @@ pub trait AsyncConnection: AsyncConnectionCore + Sized {
         f: F,
     ) -> impl Future<Output = R> + Send + 'conn
     where
-        F: for<'r> FnOnce(&'r mut Self) -> ScopedBoxFuture<'a, 'r, Result<R, E>> + Send + 'a,
+        for<'r> F: AsyncFnOnce(&'r mut Self) -> Result<R, E>
+            + AsyncFunc<&'r mut Self, Result<R, E>, Fut: Send>
+            + Send
+            + 'a,
         E: Debug + Send + 'a,
         R: Send + 'a,
         'a: 'conn,
     {
         use futures_util::TryFutureExt;
         let (user_result_tx, user_result_rx) = std::sync::mpsc::channel();
-        self.transaction::<R, _, _>(move |conn| {
+        self.transaction::<R, _, _>(async |conn| {
             f(conn)
                 .map_err(|_| diesel::result::Error::RollbackTransaction)
                 .and_then(move |r| {
                     let _ = user_result_tx.send(r);
                     std::future::ready(Err(diesel::result::Error::RollbackTransaction))
                 })
-                .scope_boxed()
+                .await
         })
         .then(move |_r| {
             let r = user_result_rx

--- a/src/pg/mod.rs
+++ b/src/pg/mod.rs
@@ -438,7 +438,6 @@ impl AsyncPgConnection {
     ///
     /// ```rust
     /// # include!("../doctest_setup.rs");
-    /// # use scoped_futures::ScopedFutureExt;
     /// #
     /// # #[tokio::main(flavor = "current_thread")]
     /// # async fn main() {
@@ -452,7 +451,7 @@ impl AsyncPgConnection {
     ///     .read_only()
     ///     .serializable()
     ///     .deferrable()
-    ///     .run(|conn| async move { Ok(()) }.scope_boxed())
+    ///     .run(async |conn| Ok(()))
     ///     .await
     /// # }
     /// ```
@@ -736,7 +735,6 @@ impl AsyncPgConnection {
     ///
     /// ```rust
     /// # include!("../doctest_setup.rs");
-    /// # use scoped_futures::ScopedFutureExt;
     /// #
     /// # #[tokio::main(flavor = "current_thread")]
     /// # async fn main() {
@@ -1087,7 +1085,6 @@ mod tests {
     use diesel::sql_types::Integer;
     use diesel::IntoSql;
     use futures_util::future::try_join;
-    use scoped_futures::ScopedFutureExt;
 
     #[tokio::test]
     async fn pipelining() {
@@ -1172,27 +1169,24 @@ mod tests {
             try_join(f3, try_join(f4, try_join(f5, try_join(f6, f7)))).await
         }
 
-        conn.transaction(|conn| {
-            async move {
-                let f12 = fn12(conn);
-                let f37 = fn37(conn);
+        conn.transaction(async |conn| {
+            let f12 = fn12(conn);
+            let f37 = fn37(conn);
 
-                let ((r1, r2), (r3, (r4, (r5, (r6, r7))))) = try_join(f12, f37).await.unwrap();
+            let ((r1, r2), (r3, (r4, (r5, (r6, r7))))) = try_join(f12, f37).await.unwrap();
 
-                assert_eq!(r1, 1);
-                assert_eq!(r2, 2);
-                assert_eq!(r3, 1);
-                assert_eq!(r4, vec![4]);
-                assert_eq!(r5, 5);
-                assert_eq!(r6, vec![6]);
-                assert_eq!(r7, 7);
+            assert_eq!(r1, 1);
+            assert_eq!(r2, 2);
+            assert_eq!(r3, 1);
+            assert_eq!(r4, vec![4]);
+            assert_eq!(r5, 5);
+            assert_eq!(r6, vec![6]);
+            assert_eq!(r7, 7);
 
-                fn12(conn).await?;
-                fn37(conn).await?;
+            fn12(conn).await?;
+            fn37(conn).await?;
 
-                QueryResult::<_>::Ok(())
-            }
-            .scope_boxed()
+            QueryResult::<_>::Ok(())
         })
         .await
         .unwrap();

--- a/src/pg/transaction_builder.rs
+++ b/src/pg/transaction_builder.rs
@@ -1,9 +1,9 @@
+use crate::transaction_manager::AsyncFunc;
 use crate::{AnsiTransactionManager, AsyncConnection, TransactionManager};
 use diesel::backend::Backend;
 use diesel::pg::Pg;
 use diesel::query_builder::{AstPass, QueryBuilder, QueryFragment};
 use diesel::QueryResult;
-use scoped_futures::ScopedBoxFuture;
 
 /// Used to build a transaction, specifying additional details.
 ///
@@ -67,7 +67,7 @@ where
     /// #     )").execute(conn).await?;
     /// conn.build_transaction()
     ///     .read_only()
-    ///     .run::<_, diesel::result::Error, _>(|conn| Box::pin(async move {
+    ///     .run::<_, diesel::result::Error, _>(async |conn| {
     ///         let read_attempt = users.select(name).load::<String>(conn).await;
     ///         assert!(read_attempt.is_ok());
     ///
@@ -78,7 +78,7 @@ where
     ///         assert!(write_attempt.is_err());
     ///
     ///         Ok(())
-    ///     }) as _).await?;
+    ///     }).await?;
     /// #     sql_query("DROP TABLE users_for_read_only").execute(conn).await?;
     /// #     Ok(())
     /// # }
@@ -112,7 +112,7 @@ where
     /// #     let conn = &mut connection_no_transaction().await;
     /// conn.build_transaction()
     ///     .read_write()
-    ///     .run(|conn| Box::pin( async move {
+    ///     .run(async |conn| {
     /// #         sql_query("CREATE TABLE IF NOT EXISTS users (
     /// #             id SERIAL PRIMARY KEY,
     /// #             name TEXT NOT NULL
@@ -130,8 +130,7 @@ where
     /// #       /*
     ///         Ok(())
     /// #       */
-    ///     }) as _)
-    ///     .await
+    ///     }).await
     /// # }
     /// ```
     pub fn read_write(mut self) -> Self {
@@ -156,7 +155,7 @@ where
     /// #     let conn = &mut connection_no_transaction().await;
     /// conn.build_transaction()
     ///     .deferrable()
-    ///     .run(|conn| Box::pin(async { Ok(()) }))
+    ///     .run(async |conn| Ok(()))
     ///     .await
     /// # }
     /// ```
@@ -185,7 +184,7 @@ where
     /// #     let conn = &mut connection_no_transaction().await;
     /// conn.build_transaction()
     ///     .not_deferrable()
-    ///     .run(|conn| Box::pin(async { Ok(()) }) as _)
+    ///     .run(async |conn| Ok(()))
     ///     .await
     /// # }
     /// ```
@@ -214,7 +213,7 @@ where
     /// #     let conn = &mut connection_no_transaction().await;
     /// conn.build_transaction()
     ///     .read_committed()
-    ///     .run(|conn| Box::pin(async { Ok(()) }) as _)
+    ///     .run(async |conn| Ok(()))
     ///     .await
     /// # }
     /// ```
@@ -240,7 +239,7 @@ where
     /// #     let conn = &mut connection_no_transaction().await;
     /// conn.build_transaction()
     ///     .repeatable_read()
-    ///     .run(|conn| Box::pin(async { Ok(()) }) as _)
+    ///     .run(async |conn| Ok(()))
     ///     .await
     /// # }
     /// ```
@@ -266,7 +265,7 @@ where
     /// #     let conn = &mut connection_no_transaction().await;
     /// conn.build_transaction()
     ///     .serializable()
-    ///     .run(|conn| Box::pin(async { Ok(()) }) as _)
+    ///     .run(async |conn| Ok(()) )
     ///     .await
     /// # }
     /// ```
@@ -288,7 +287,10 @@ where
     /// as it contains a uncommitted unabortable open transaction.
     pub async fn run<'b, T, E, F>(&mut self, f: F) -> Result<T, E>
     where
-        F: for<'r> FnOnce(&'r mut C) -> ScopedBoxFuture<'b, 'r, Result<T, E>> + Send + 'a,
+        for<'r> F: AsyncFnOnce(&'r mut C) -> Result<T, E>
+            + AsyncFunc<&'r mut C, Result<T, E>, Fut: Send>
+            + Send
+            + 'a,
         T: 'b,
         E: From<diesel::result::Error> + 'b,
     {

--- a/src/sync_connection_wrapper/sqlite.rs
+++ b/src/sync_connection_wrapper/sqlite.rs
@@ -1,8 +1,8 @@
 use diesel::connection::AnsiTransactionManager;
 use diesel::SqliteConnection;
-use scoped_futures::ScopedBoxFuture;
 
 use crate::sync_connection_wrapper::SyncTransactionManagerWrapper;
+use crate::transaction_manager::AsyncFunc;
 use crate::TransactionManager;
 
 use super::SyncConnectionWrapper;
@@ -21,7 +21,6 @@ impl SyncConnectionWrapper<SqliteConnection> {
     /// ```rust
     /// # include!("../doctest_setup.rs");
     /// use diesel::result::Error;
-    /// use scoped_futures::ScopedFutureExt;
     /// use diesel_async::{RunQueryDsl, AsyncConnection};
     /// #
     /// # #[tokio::main(flavor = "current_thread")]
@@ -32,7 +31,7 @@ impl SyncConnectionWrapper<SqliteConnection> {
     /// # async fn run_test() -> QueryResult<()> {
     /// #     use schema::users::dsl::*;
     /// #     let conn = &mut connection_no_transaction().await;
-    /// conn.immediate_transaction(|conn| async move {
+    /// conn.immediate_transaction(async |conn| {
     ///     diesel::insert_into(users)
     ///         .values(name.eq("Ruby"))
     ///         .execute(conn)
@@ -42,12 +41,15 @@ impl SyncConnectionWrapper<SqliteConnection> {
     ///     assert_eq!(vec!["Sean", "Tess", "Ruby"], all_names);
     ///
     ///     Ok(())
-    /// }.scope_boxed()).await
+    /// }).await
     /// # }
     /// ```
     pub async fn immediate_transaction<'a, R, E, F>(&mut self, f: F) -> Result<R, E>
     where
-        F: for<'r> FnOnce(&'r mut Self) -> ScopedBoxFuture<'a, 'r, Result<R, E>> + Send + 'a,
+        for<'r> F: AsyncFnOnce(&'r mut Self) -> Result<R, E>
+            + AsyncFunc<&'r mut Self, Result<R, E>, Fut: Send>
+            + Send
+            + 'a,
         E: From<diesel::result::Error> + Send + 'a,
         R: Send + 'a,
     {
@@ -67,7 +69,6 @@ impl SyncConnectionWrapper<SqliteConnection> {
     /// ```rust
     /// # include!("../doctest_setup.rs");
     /// use diesel::result::Error;
-    /// use scoped_futures::ScopedFutureExt;
     /// use diesel_async::{RunQueryDsl, AsyncConnection};
     /// #
     /// # #[tokio::main(flavor = "current_thread")]
@@ -78,7 +79,7 @@ impl SyncConnectionWrapper<SqliteConnection> {
     /// # async fn run_test() -> QueryResult<()> {
     /// #     use schema::users::dsl::*;
     /// #     let conn = &mut connection_no_transaction().await;
-    /// conn.exclusive_transaction(|conn| async move {
+    /// conn.exclusive_transaction(async |conn|  {
     ///     diesel::insert_into(users)
     ///         .values(name.eq("Ruby"))
     ///         .execute(conn)
@@ -88,12 +89,15 @@ impl SyncConnectionWrapper<SqliteConnection> {
     ///     assert_eq!(vec!["Sean", "Tess", "Ruby"], all_names);
     ///
     ///     Ok(())
-    /// }.scope_boxed()).await
+    /// }).await
     /// # }
     /// ```
     pub async fn exclusive_transaction<'a, R, E, F>(&mut self, f: F) -> Result<R, E>
     where
-        F: for<'r> FnOnce(&'r mut Self) -> ScopedBoxFuture<'a, 'r, Result<R, E>> + Send + 'a,
+        for<'r> F: AsyncFnOnce(&'r mut Self) -> Result<R, E>
+            + AsyncFunc<&'r mut Self, Result<R, E>, Fut: Send>
+            + Send
+            + 'a,
         E: From<diesel::result::Error> + Send + 'a,
         R: Send + 'a,
     {
@@ -102,7 +106,10 @@ impl SyncConnectionWrapper<SqliteConnection> {
 
     async fn transaction_sql<'a, R, E, F>(&mut self, f: F, sql: &'static str) -> Result<R, E>
     where
-        F: for<'r> FnOnce(&'r mut Self) -> ScopedBoxFuture<'a, 'r, Result<R, E>> + Send + 'a,
+        for<'r> F: AsyncFnOnce(&'r mut Self) -> Result<R, E>
+            + AsyncFunc<&'r mut Self, Result<R, E>, Fut: Send>
+            + Send
+            + 'a,
         E: From<diesel::result::Error> + Send + 'a,
         R: Send + 'a,
     {

--- a/src/transaction_manager.rs
+++ b/src/transaction_manager.rs
@@ -5,12 +5,47 @@ use diesel::connection::{
 };
 use diesel::result::Error;
 use diesel::QueryResult;
-use scoped_futures::ScopedBoxFuture;
 use std::borrow::Cow;
 use std::future::Future;
 use std::num::NonZeroU32;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+
+/// A helper trait to allow us asserting additional bounds on `AsyncFnOnce`
+/// Especially this lets us assert bounds on the future returned by the closure
+/// while still maintaining working type inference for the closure
+///
+/// This mostly exists for the following reasons:
+///
+/// * `AsyncFnOnce::CallOnceFuture` is not stable, so you cannot assert only with `AsyncFnOnce` that
+///   the returned future is `Send`
+/// * Only using `FnOnce(T) -> impl Future` doesn't work as you cannot use `impl Future` in that position
+/// * Using `F: FnOnce(T) -> Fut, Fut: Future<…>` doesn't work as you run into diverging lifetimes,
+///   as you essentially need to reuse the higher ranked lifetime from the closure to also restrict
+///   the lifetime of the returned future
+/// * Using a `trait Func<T>: FnOnce(T) -> <Self as Func<T>::Output> { type Output }` allows us
+///   to restrict the lifetime and bounds (like `Future` and `Send`) on the output type of the closure
+///   but then fails in type inference due to rustc bugs. You get unhelpful errors like
+///   `implementation of `FnOnce` is not general enough`, this can be side stepped by putting
+///   types on the calling side of the closure, which is not that nice API wise
+///
+/// This workaround is still not optimal as it still requires us to have this trait and show
+/// it as public bound. We somewhat try to avoid confusing users there by having an additional
+/// `AsyncFnOnce(T) -> R` bound at the calling side that hopefully will show up in rustdoc
+/// as well and hopefully guides the user to do the "right thing"
+pub trait AsyncFunc<T, R>:
+    AsyncFnOnce(T) -> R + FnOnce(T) -> <Self as AsyncFunc<T, R>>::Fut
+{
+    type Fut: Future<Output = R>;
+}
+
+impl<F, T, Fut, R> AsyncFunc<T, R> for F
+where
+    F: AsyncFnOnce(T) -> R + FnOnce(T) -> Fut,
+    Fut: Future<Output = R>,
+{
+    type Fut = Fut;
+}
 
 use crate::AsyncConnection;
 // TODO: refactor this to share more code with diesel
@@ -62,7 +97,10 @@ pub trait TransactionManager<Conn: AsyncConnection>: Send {
         callback: F,
     ) -> impl Future<Output = Result<R, E>> + Send + 'conn
     where
-        F: for<'r> FnOnce(&'r mut Conn) -> ScopedBoxFuture<'a, 'r, Result<R, E>> + Send + 'a,
+        for<'r> F: AsyncFnOnce(&'r mut Conn) -> Result<R, E>
+            + AsyncFunc<&'r mut Conn, Result<R, E>, Fut: Send>
+            + Send
+            + 'a,
         E: From<Error> + Send,
         R: Send,
         'a: 'conn,

--- a/tests/instrumentation.rs
+++ b/tests/instrumentation.rs
@@ -204,7 +204,7 @@ async fn check_events_are_emitted_for_load_repeat_does_not_repeat_cache() {
 #[tokio::test]
 async fn check_events_transaction() {
     let (events_to_check, mut conn) = setup_test_case().await;
-    conn.transaction(|_conn| Box::pin(async { QueryResult::Ok(()) }))
+    conn.transaction(async |_conn| QueryResult::Ok(()))
         .await
         .unwrap();
     let events = events_to_check.lock().unwrap();
@@ -221,8 +221,8 @@ async fn check_events_transaction() {
 async fn check_events_transaction_error() {
     let (events_to_check, mut conn) = setup_test_case().await;
     let _ = conn
-        .transaction(|_conn| {
-            Box::pin(async { QueryResult::<()>::Err(diesel::result::Error::RollbackTransaction) })
+        .transaction(async |_conn| {
+            QueryResult::<()>::Err(diesel::result::Error::RollbackTransaction)
         })
         .await;
     let events = events_to_check.lock().unwrap();
@@ -238,14 +238,9 @@ async fn check_events_transaction_error() {
 #[tokio::test]
 async fn check_events_transaction_nested() {
     let (events_to_check, mut conn) = setup_test_case().await;
-    conn.transaction(|conn| {
-        Box::pin(async move {
-            conn.transaction(|_conn| Box::pin(async { QueryResult::Ok(()) }))
-                .await
-        })
-    })
-    .await
-    .unwrap();
+    conn.transaction(async |conn| conn.transaction(async |_conn| QueryResult::Ok(())).await)
+        .await
+        .unwrap();
     let events = events_to_check.lock().unwrap();
     assert_eq!(events.len(), 12, "{events:?}");
     assert_matches!(events[0], Event::BeginTransaction { .. });
@@ -267,12 +262,11 @@ async fn check_events_transaction_nested() {
 async fn check_events_transaction_builder() {
     use crate::connection_without_transaction;
     use diesel::result::Error;
-    use scoped_futures::ScopedFutureExt;
 
     let (events_to_check, mut conn) =
         setup_test_case_with_connection(connection_without_transaction().await);
     conn.build_transaction()
-        .run(|_tx| async move { Ok::<(), Error>(()) }.scope_boxed())
+        .run(async |_tx| Ok::<(), Error>(()))
         .await
         .unwrap();
     let events = events_to_check.lock().unwrap();

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,6 @@
 use diesel::prelude::{ExpressionMethods, OptionalExtension, QueryDsl};
 use diesel::QueryResult;
 use diesel_async::*;
-use scoped_futures::ScopedFutureExt;
 use std::fmt::Debug;
 
 #[cfg(feature = "postgres")]
@@ -21,45 +20,39 @@ async fn transaction_test<C: AsyncConnection<Backend = TestBackend>>(
     conn: &mut C,
 ) -> QueryResult<()> {
     let res = conn
-        .transaction::<i32, diesel::result::Error, _>(|conn| {
-            async move {
-                let users: Vec<User> = users::table.load(conn).await?;
-                assert_eq!(&users[0].name, "John Doe");
-                assert_eq!(&users[1].name, "Jane Doe");
+        .transaction::<i32, diesel::result::Error, _>(async |conn| {
+            let users: Vec<User> = users::table.load(conn).await?;
+            assert_eq!(&users[0].name, "John Doe");
+            assert_eq!(&users[1].name, "Jane Doe");
 
-                let user: Option<User> = users::table.find(42).first(conn).await.optional()?;
-                assert_eq!(user, None::<User>);
+            let user: Option<User> = users::table.find(42).first(conn).await.optional()?;
+            assert_eq!(user, None::<User>);
 
-                let res = conn
-                    .transaction::<_, diesel::result::Error, _>(|conn| {
-                        async move {
-                            diesel::insert_into(users::table)
-                                .values(users::name.eq("Dave"))
-                                .execute(conn)
-                                .await?;
-                            let count = users::table.count().get_result::<i64>(conn).await?;
-                            assert_eq!(count, 3);
-                            Ok(())
-                        }
-                        .scope_boxed()
-                    })
-                    .await;
-                assert!(res.is_ok());
-                let count = users::table.count().get_result::<i64>(conn).await?;
-                assert_eq!(count, 3);
+            let res = conn
+                .transaction::<_, diesel::result::Error, _>(async |conn| {
+                    diesel::insert_into(users::table)
+                        .values(users::name.eq("Dave"))
+                        .execute(conn)
+                        .await?;
+                    let count = users::table.count().get_result::<i64>(conn).await?;
+                    assert_eq!(count, 3);
+                    Ok(())
+                })
+                .await;
+            assert!(res.is_ok());
+            let count = users::table.count().get_result::<i64>(conn).await?;
+            assert_eq!(count, 3);
 
-                let res = diesel::insert_into(users::table)
-                    .values(users::name.eq("Eve"))
-                    .execute(conn)
-                    .await?;
+            let res = diesel::insert_into(users::table)
+                .values(users::name.eq("Eve"))
+                .execute(conn)
+                .await?;
 
-                assert_eq!(res, 1, "Insert in transaction returned wrong result");
-                let count = users::table.count().get_result::<i64>(conn).await?;
-                assert_eq!(count, 4);
+            assert_eq!(res, 1, "Insert in transaction returned wrong result");
+            let count = users::table.count().get_result::<i64>(conn).await?;
+            assert_eq!(count, 4);
 
-                Err(diesel::result::Error::RollbackTransaction)
-            }
-            .scope_boxed()
+            Err(diesel::result::Error::RollbackTransaction)
         })
         .await;
     assert_eq!(

--- a/tests/transactions.rs
+++ b/tests/transactions.rs
@@ -34,39 +34,35 @@ async fn concurrent_serializable_transactions_behave_correctly() {
 
     let mut tx = conn.build_transaction().serializable().read_write();
 
-    let res = tx.run(|conn| {
-        Box::pin(async {
-            users3::table.select(users3::id).load::<i32>(conn).await?;
+    let res = tx.run(async |conn| {
+        users3::table.select(users3::id).load::<i32>(conn).await?;
 
-            barrier_1_for_tx1.wait().await;
-            diesel::insert_into(users3::table)
-                .values(users3::id.eq(1))
-                .execute(conn)
-                .await?;
-            barrier_3_for_tx1.wait().await;
-            barrier_2_for_tx1.wait().await;
+        barrier_1_for_tx1.wait().await;
+        diesel::insert_into(users3::table)
+            .values(users3::id.eq(1))
+            .execute(conn)
+            .await?;
+        barrier_3_for_tx1.wait().await;
+        barrier_2_for_tx1.wait().await;
 
-            Ok::<_, diesel::result::Error>(())
-        })
+        Ok::<_, diesel::result::Error>(())
     });
 
     let mut tx1 = conn1.build_transaction().serializable().read_write();
 
     let res1 = async {
         let res = tx1
-            .run(|conn| {
-                Box::pin(async {
-                    users3::table.select(users3::id).load::<i32>(conn).await?;
+            .run(async |conn| {
+                users3::table.select(users3::id).load::<i32>(conn).await?;
 
-                    barrier_1_for_tx2.wait().await;
-                    diesel::insert_into(users3::table)
-                        .values(users3::id.eq(1))
-                        .execute(conn)
-                        .await?;
-                    barrier_3_for_tx2.wait().await;
+                barrier_1_for_tx2.wait().await;
+                diesel::insert_into(users3::table)
+                    .values(users3::id.eq(1))
+                    .execute(conn)
+                    .await?;
+                barrier_3_for_tx2.wait().await;
 
-                    Ok::<_, diesel::result::Error>(())
-                })
+                Ok::<_, diesel::result::Error>(())
             })
             .await;
         barrier_2_for_tx2.wait().await;
@@ -99,9 +95,7 @@ async fn concurrent_serializable_transactions_behave_correctly() {
 
     let mut tx = conn.build_transaction();
 
-    let res = tx
-        .run(|_| Box::pin(async { Ok::<_, diesel::result::Error>(()) }))
-        .await;
+    let res = tx.run(async |_| Ok::<_, diesel::result::Error>(())).await;
 
     assert!(
         res.is_ok(),
@@ -161,39 +155,35 @@ async fn commit_with_serialization_failure_already_ends_transaction() {
 
     let mut tx = conn.build_transaction().serializable().read_write();
 
-    let res = tx.run(|conn| {
-        Box::pin(async {
-            users4::table.select(users4::id).load::<i32>(conn).await?;
+    let res = tx.run(async |conn| {
+        users4::table.select(users4::id).load::<i32>(conn).await?;
 
-            barrier_1_for_tx1.wait().await;
-            diesel::insert_into(users4::table)
-                .values(users4::id.eq(1))
-                .execute(conn)
-                .await?;
-            barrier_3_for_tx1.wait().await;
-            barrier_2_for_tx1.wait().await;
+        barrier_1_for_tx1.wait().await;
+        diesel::insert_into(users4::table)
+            .values(users4::id.eq(1))
+            .execute(conn)
+            .await?;
+        barrier_3_for_tx1.wait().await;
+        barrier_2_for_tx1.wait().await;
 
-            Ok::<_, diesel::result::Error>(())
-        })
+        Ok::<_, diesel::result::Error>(())
     });
 
     let mut tx1 = conn1.build_transaction().serializable().read_write();
 
     let res1 = async {
         let res = tx1
-            .run(|conn| {
-                Box::pin(async {
-                    users4::table.select(users4::id).load::<i32>(conn).await?;
+            .run(async |conn| {
+                users4::table.select(users4::id).load::<i32>(conn).await?;
 
-                    barrier_1_for_tx2.wait().await;
-                    diesel::insert_into(users4::table)
-                        .values(users4::id.eq(1))
-                        .execute(conn)
-                        .await?;
-                    barrier_3_for_tx2.wait().await;
+                barrier_1_for_tx2.wait().await;
+                diesel::insert_into(users4::table)
+                    .values(users4::id.eq(1))
+                    .execute(conn)
+                    .await?;
+                barrier_3_for_tx2.wait().await;
 
-                    Ok::<_, diesel::result::Error>(())
-                })
+                Ok::<_, diesel::result::Error>(())
             })
             .await;
         barrier_2_for_tx2.wait().await;
@@ -226,9 +216,7 @@ async fn commit_with_serialization_failure_already_ends_transaction() {
 
     let mut tx = conn.build_transaction();
 
-    let res = tx
-        .run(|_| Box::pin(async { Ok::<_, diesel::result::Error>(()) }))
-        .await;
+    let res = tx.run(async |_| Ok::<_, diesel::result::Error>(())).await;
 
     assert!(
         res.is_ok(),


### PR DESCRIPTION
This commit changes all transaction related functions to use real async closures instead of closures returning a boxed future. This resolves a long standing issue in expressing the right bounds for this closure and the relevant return type.

A huge thanks to lcnr who helped to figure out a working workaround for all the involed bugs in rustc: https://github.com/lcnr/random-rust-snippets/issues/26