### PR TITLE
Prepare a 0.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
 
-## [Unreleased]
+## [0.9.0] - 2026-04-30
 
 * Change all transaction related functions to accept an real async closure instead of 
   the scoped boxed variant. This change requires adujsting all call sides of transaction 
   based functions from `conn.transaction(|conn| async move {/* your code */}.scoped_boxed())`
   to `conn.transaction(async |conn| /* your code */)`
-
+* Fixed an unsound access to padding values while deserializing Date/Time values in the mysql backend
+  Thanks to Paolo Barbolini for finding this issue.
+  
 ## [0.8.0] - 2026-03-20
 
 * Added support for UpdateAndFetchResults for `SyncConnectionWrapper`, allowing to use `save_changes`
@@ -142,4 +144,5 @@ in the pool should be checked if they are still valid
 [0.7.3]: https://github.com/weiznich/diesel_async/compare/v0.7.2...v0.7.3
 [0.7.4]: https://github.com/weiznich/diesel_async/compare/v0.7.3...v0.7.4
 [0.8.0]: https://github.com/weiznich/diesel_async/compare/v0.7.4...v0.8.0
-[Unreleased]: https://github.com/weiznich/diesel_async/compare/v0.8.0...main
+[0.9.0]: https://github.com/weiznich/diesel_async/compare/v0.8.0...v0.9.0
+[Unreleased]: https://github.com/weiznich/diesel_async/compare/v0.9.0...main

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel-async"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Georg Semmler <github@weiznich.de>"]
 edition = "2021"
 autotests = false
@@ -39,7 +39,7 @@ mobc = { version = ">=0.7,<0.10", optional = true }
 pin-project-lite = "0.2.17"
 
 [dependencies.diesel]
-version = "~2.3.0"
+version = "~2.3.9"
 default-features = false
 features = [
   "i-implement-a-third-party-backend-and-opt-into-breaking-changes",

--- a/examples/postgres/pipelining/Cargo.toml
+++ b/examples/postgres/pipelining/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-diesel-async = { version = "0.8.0", path = "../../../", features = ["bb8", "postgres"] }
+diesel-async = { version = "0.9.0", path = "../../../", features = ["bb8", "postgres"] }
 tokio = { version = "1.2.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 
 [dependencies.diesel]

--- a/examples/postgres/pooled-with-rustls/Cargo.toml
+++ b/examples/postgres/pooled-with-rustls/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-diesel-async = { version = "0.8.0", path = "../../../", features = ["bb8", "postgres"] }
+diesel-async = { version = "0.9.0", path = "../../../", features = ["bb8", "postgres"] }
 futures-util = "0.3.21"
 rustls = "0.23.8"
 rustls-platform-verifier = "0.5.0"

--- a/examples/postgres/run-pending-migrations-with-rustls/Cargo.toml
+++ b/examples/postgres/run-pending-migrations-with-rustls/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-diesel-async = { version = "0.8.0", path = "../../../", features = ["bb8", "postgres", "migrations"] }
+diesel-async = { version = "0.9.0", path = "../../../", features = ["bb8", "postgres", "migrations"] }
 futures-util = "0.3.21"
 rustls = "0.23.8"
 rustls-platform-verifier = "0.5.0"

--- a/examples/sync-wrapper/Cargo.toml
+++ b/examples/sync-wrapper/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-diesel-async = { version = "0.8.0", path = "../../", features = ["sync-connection-wrapper", "async-connection-wrapper"] }
+diesel-async = { version = "0.9.0", path = "../../", features = ["sync-connection-wrapper", "async-connection-wrapper"] }
 futures-util = "0.3.21"
 tokio = { version = "1.2.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 

--- a/src/mysql/row.rs
+++ b/src/mysql/row.rs
@@ -75,11 +75,7 @@ impl<'a> diesel::row::Row<'a, Mysql> for MysqlRow {
                     MysqlTimestampType::MYSQL_TIMESTAMP_TIME,
                     0,
                 );
-                let buffer = unsafe {
-                    let ptr = &date as *const MysqlTime as *const u8;
-                    let slice = std::slice::from_raw_parts(ptr, std::mem::size_of::<MysqlTime>());
-                    slice.to_vec()
-                };
+                let buffer = date.serialize().to_vec();
                 Some(Cow::Owned(buffer))
             }
             Value::Date(year, month, day, hour, minute, second, second_part) => {
@@ -95,11 +91,7 @@ impl<'a> diesel::row::Row<'a, Mysql> for MysqlRow {
                     MysqlTimestampType::MYSQL_TIMESTAMP_DATETIME,
                     0,
                 );
-                let buffer = unsafe {
-                    let ptr = &date as *const MysqlTime as *const u8;
-                    let slice = std::slice::from_raw_parts(ptr, std::mem::size_of::<MysqlTime>());
-                    slice.to_vec()
-                };
+                let buffer = date.serialize().to_vec();
                 Some(Cow::Owned(buffer))
             }
             _t => {


### PR DESCRIPTION
This includes the async closure changes and a fix for an unsoundness while deserializing mysql date/time values.

This needs to wait for the diesel 2.3.9 release to make the relevant helper method public.

cc @paolobarbolini as you reported the underlying issue.