### PR TITLE
Correctly check if a connection returned to a mobc pool is still usable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
 
+## [0.9.1] - 2026-06-05
+
+* Correctly check if a connection is a broken state (e.g. has an open transaction) for the mobc pool implementation
+
 ## [0.9.0] - 2026-04-30
 
 * Change all transaction related functions to accept an real async closure instead of 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel-async"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Georg Semmler <github@weiznich.de>"]
 edition = "2021"
 autotests = false

--- a/src/pooled_connection/mobc.rs
+++ b/src/pooled_connection/mobc.rs
@@ -90,4 +90,8 @@ where
             .map_err(PoolError::QueryError)?;
         Ok(conn)
     }
+
+    fn validate(&self, conn: &mut Self::Connection) -> bool {
+        std::thread::panicking() || conn.is_broken()
+    }
 }


### PR DESCRIPTION
This commit adds an additional check to the mobc manager implementation to check if the connection is still valid if it's returned to the pool. This checks for open transactions and if we are currently panicing. This check mirrors the checks we do for the other pool implementations as well. For some reason it was missing for mobc.