### PR TITLE
Map restrict and exclusion violations in `from_tokio_postgres_error` used in PG18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,9 @@ jobs:
             sudo apt-get install -y postgresql-common
             sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
             sudo apt-get install -y "postgresql-$PG_VERSION"
-            sudo systemctl restart "postgresql@$PG_VERSION-main"
+            sudo pg_dropcluster --stop "$PG_VERSION" main 2>/dev/null || true
+            sudo pg_createcluster "$PG_VERSION" main
+            sudo pg_ctlcluster --skip-systemctl-redirect "$PG_VERSION" main start
             port=$(pg_lsclusters -h | awk -v v="$PG_VERSION" '$1 == v {print $3}')
           else
             sudo apt-get install -y postgresql

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,21 @@ jobs:
             windows-latest,
             ubuntu-24.04-arm,
           ]
+        exclude:
+          - rust: "stable"
+            backend: "postgres"
+            os: "ubuntu-latest"
         include:
+          # Adding two extra jobs for the single one exlucded above with pinned postgres versions
+          # as there is a change in behaviour (see `restrict_violation_error_kind` test)
+          - rust: "stable"
+            backend: "postgres"
+            os: "ubuntu-latest"
+            pg_version: "17"
+          - rust: "stable"
+            backend: "postgres"
+            os: "ubuntu-latest"
+            pg_version: "18"
           - rust: "beta"
             backend: "postgres"
             os: "ubuntu-latest"
@@ -92,14 +106,25 @@ jobs:
 
       - name: Install postgres (Linux)
         if: runner.os == 'Linux' && matrix.backend == 'postgres'
+        env:
+          PG_VERSION: ${{ matrix.pg_version }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y postgresql
-          echo "host    all             all             127.0.0.1/32            md5" > sudo tee -a /etc/postgresql/10/main/pg_hba.conf
-          sudo service postgresql restart && sleep 3
-          sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
-          sudo service postgresql restart && sleep 3
-          echo "DATABASE_URL=postgres://postgres:postgres@localhost/" >> $GITHUB_ENV
+          if [ -n "$PG_VERSION" ]; then
+            # See https://www.postgresql.org/download/linux/ubuntu/
+            sudo apt-get install -y postgresql-common
+            sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+            sudo apt-get install -y "postgresql-$PG_VERSION"
+            sudo systemctl restart "postgresql@$PG_VERSION-main"
+            port=$(pg_lsclusters -h | awk -v v="$PG_VERSION" '$1 == v {print $3}')
+          else
+            sudo apt-get install -y postgresql
+            sudo service postgresql restart
+            port=5432
+          fi
+          sleep 3
+          sudo -u postgres psql -p "$port" -c "ALTER USER postgres PASSWORD 'postgres';"
+          echo "DATABASE_URL=postgres://postgres:postgres@localhost:$port/" >> "$GITHUB_ENV"
 
       - name: Install mysql (Linux)
         if: runner.os == 'Linux' && matrix.backend == 'mysql'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
         run: |
           choco install sqlite
           cd /D C:\ProgramData\chocolatey\lib\SQLite\tools
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          for /f "usebackq tokens=*" %%i in (`"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease -property installationPath`) do call "%%i\VC\Auxiliary\Build\vcvars64.bat"
           lib /machine:x64 /def:sqlite3.def /out:sqlite3.lib
 
       - name: Set variables for sqlite (Windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,13 @@ on:
 name: CI Tests
 permissions:
   contents: "read"
+env:
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+  # Force HTTP/1.1 for crates.io downloads: HTTP/2 multiplexing against the
+  # CDN intermittently drops connections mid-stream (SSL "unexpected eof"),
+  # and cargo does not retry those, so CARGO_NET_RETRY alone cannot recover.
+  CARGO_HTTP_MULTIPLEXING: "false"
 
 # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
 # This will ensure that only one commit will be running tests at a time on each PR.
@@ -109,18 +116,18 @@ jobs:
         env:
           PG_VERSION: ${{ matrix.pg_version }}
         run: |
-          sudo apt-get update
+          sudo apt-get -o DPkg::Lock::Timeout=300 update
           if [ -n "$PG_VERSION" ]; then
             # See https://www.postgresql.org/download/linux/ubuntu/
-            sudo apt-get install -y postgresql-common
+            sudo apt-get -o DPkg::Lock::Timeout=300 install -y postgresql-common
             sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
-            sudo apt-get install -y "postgresql-$PG_VERSION"
+            sudo apt-get -o DPkg::Lock::Timeout=300 install -y "postgresql-$PG_VERSION"
             sudo pg_dropcluster --stop "$PG_VERSION" main 2>/dev/null || true
             sudo pg_createcluster "$PG_VERSION" main
             sudo pg_ctlcluster --skip-systemctl-redirect "$PG_VERSION" main start
             port=$(pg_lsclusters -h | awk -v v="$PG_VERSION" '$1 == v {print $3}')
           else
-            sudo apt-get install -y postgresql
+            sudo apt-get -o DPkg::Lock::Timeout=300 install -y postgresql
             sudo service postgresql restart
             port=5432
           fi
@@ -138,8 +145,8 @@ jobs:
       - name: Install sqlite (Linux)
         if: runner.os == 'Linux' && matrix.backend == 'sqlite'
         run: |
-          sudo apt-get update
-          sudo apt-get install libsqlite3-dev
+          sudo apt-get -o DPkg::Lock::Timeout=300 update
+          sudo apt-get -o DPkg::Lock::Timeout=300 install libsqlite3-dev
           echo "DATABASE_URL=:memory:" >> $GITHUB_ENV
 
       - name: Install postgres (MacOS)

--- a/src/pg/error_helper.rs
+++ b/src/pg/error_helper.rs
@@ -28,6 +28,8 @@ pub(super) fn from_tokio_postgres_error(
             let kind = match *code {
                 SqlState::UNIQUE_VIOLATION => UniqueViolation,
                 SqlState::FOREIGN_KEY_VIOLATION => ForeignKeyViolation,
+                SqlState::RESTRICT_VIOLATION => RestrictViolation,
+                SqlState::EXCLUSION_VIOLATION => ExclusionViolation,
                 SqlState::T_R_SERIALIZATION_FAILURE => SerializationFailure,
                 SqlState::READ_ONLY_SQL_TRANSACTION => ReadOnlyTransaction,
                 SqlState::NOT_NULL_VIOLATION => NotNullViolation,

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,10 +1,10 @@
 use crate::connection;
+use assert_matches::assert_matches;
 use diesel::dsl::{delete, insert_into, sql};
 use diesel::result::{DatabaseErrorKind, Error};
 use diesel::sql_types::Integer;
 use diesel::{table, Insertable};
 use diesel_async::{RunQueryDsl, SimpleAsyncConnection};
-use assert_matches::assert_matches;
 
 table! {
     use diesel::sql_types::*;
@@ -62,17 +62,18 @@ async fn unique_violation_error_kind() {
 async fn foreign_key_violation_error_kind() {
     let connection = &mut connection().await;
 
-    connection.batch_execute(
-        r#"
+    connection
+        .batch_execute(
+            r#"
             CREATE TABLE parent (id INTEGER PRIMARY KEY);
             CREATE TABLE child (
                 id INTEGER PRIMARY KEY,
                 parent_id INTEGER REFERENCES parent(id) ON DELETE RESTRICT
             );
         "#,
-    )
-    .await
-    .unwrap();
+        )
+        .await
+        .unwrap();
 
     let err = insert_into(child::table)
         .values(&[Child {
@@ -90,17 +91,18 @@ async fn foreign_key_violation_error_kind() {
 async fn restrict_violation_error_kind() {
     let connection = &mut connection().await;
 
-    connection.batch_execute(
-        r#"
+    connection
+        .batch_execute(
+            r#"
             CREATE TABLE parent (id INTEGER PRIMARY KEY);
             CREATE TABLE child (
                 id INTEGER PRIMARY KEY,
                 parent_id INTEGER REFERENCES parent(id) ON DELETE RESTRICT
             );
         "#,
-    )
-    .await
-    .unwrap();
+        )
+        .await
+        .unwrap();
 
     insert_into(parent::table)
         .values(&[Parent { id: 1 }])
@@ -117,11 +119,12 @@ async fn restrict_violation_error_kind() {
         .await
         .unwrap();
 
-    let pg_version_num =
-        diesel::select(sql::<Integer>("current_setting('server_version_num')::integer"))
-            .get_result::<i32>(connection)
-            .await
-            .unwrap();
+    let pg_version_num = diesel::select(sql::<Integer>(
+        "current_setting('server_version_num')::integer",
+    ))
+    .get_result::<i32>(connection)
+    .await
+    .unwrap();
 
     let err = delete(parent::table).execute(connection).await.unwrap_err();
 
@@ -210,6 +213,6 @@ async fn check_violation_error_kind() {
         .execute(connection)
         .await
         .unwrap_err();
-    
+
     assert_matches!(err, Error::DatabaseError(kind, _) if kind == DatabaseErrorKind::CheckViolation);
 }

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,0 +1,215 @@
+use crate::connection;
+use diesel::dsl::{delete, insert_into, sql};
+use diesel::result::{DatabaseErrorKind, Error};
+use diesel::sql_types::Integer;
+use diesel::{table, Insertable};
+use diesel_async::{RunQueryDsl, SimpleAsyncConnection};
+use assert_matches::assert_matches;
+
+table! {
+    use diesel::sql_types::*;
+    parent {
+        id -> Integer,
+    }
+}
+
+table! {
+    use diesel::sql_types::*;
+    child {
+        id -> Integer,
+        parent_id -> Integer,
+    }
+}
+
+#[derive(Insertable, Debug)]
+#[diesel(table_name = parent)]
+struct Parent {
+    id: i32,
+}
+
+#[derive(Insertable, Debug)]
+#[diesel(table_name = child)]
+struct Child {
+    id: i32,
+    parent_id: i32,
+}
+
+#[tokio::test]
+async fn unique_violation_error_kind() {
+    let connection = &mut connection().await;
+
+    diesel::sql_query("CREATE TABLE parent (id INTEGER PRIMARY KEY)")
+        .execute(connection)
+        .await
+        .unwrap();
+
+    insert_into(parent::table)
+        .values(&[Parent { id: 1 }])
+        .execute(connection)
+        .await
+        .unwrap();
+
+    let err = insert_into(parent::table)
+        .values(&[Parent { id: 1 }])
+        .execute(connection)
+        .await
+        .unwrap_err();
+
+    assert_matches!(err, Error::DatabaseError(kind, _) if kind == DatabaseErrorKind::UniqueViolation);
+}
+
+#[tokio::test]
+async fn foreign_key_violation_error_kind() {
+    let connection = &mut connection().await;
+
+    connection.batch_execute(
+        r#"
+            CREATE TABLE parent (id INTEGER PRIMARY KEY);
+            CREATE TABLE child (
+                id INTEGER PRIMARY KEY,
+                parent_id INTEGER REFERENCES parent(id) ON DELETE RESTRICT
+            );
+        "#,
+    )
+    .await
+    .unwrap();
+
+    let err = insert_into(child::table)
+        .values(&[Child {
+            id: 0,
+            parent_id: 0,
+        }])
+        .execute(connection)
+        .await
+        .unwrap_err();
+
+    assert_matches!(err, Error::DatabaseError(kind, _) if kind == DatabaseErrorKind::ForeignKeyViolation);
+}
+
+#[tokio::test]
+async fn restrict_violation_error_kind() {
+    let connection = &mut connection().await;
+
+    connection.batch_execute(
+        r#"
+            CREATE TABLE parent (id INTEGER PRIMARY KEY);
+            CREATE TABLE child (
+                id INTEGER PRIMARY KEY,
+                parent_id INTEGER REFERENCES parent(id) ON DELETE RESTRICT
+            );
+        "#,
+    )
+    .await
+    .unwrap();
+
+    insert_into(parent::table)
+        .values(&[Parent { id: 1 }])
+        .execute(connection)
+        .await
+        .unwrap();
+
+    insert_into(child::table)
+        .values(&[Child {
+            id: 0,
+            parent_id: 1,
+        }])
+        .execute(connection)
+        .await
+        .unwrap();
+
+    let pg_version_num =
+        diesel::select(sql::<Integer>("current_setting('server_version_num')::integer"))
+            .get_result::<i32>(connection)
+            .await
+            .unwrap();
+
+    let err = delete(parent::table).execute(connection).await.unwrap_err();
+
+    // Postgres 18 changed the error code raised by the RESTRICT referential
+    // action from `FOREIGN KEY VIOLATION` to `RESTRICT VIOLATION`, see
+    // https://github.com/postgres/postgres/commit/086c84b23d
+    let expected_kind = if pg_version_num >= 180_000 {
+        DatabaseErrorKind::RestrictViolation
+    } else {
+        DatabaseErrorKind::ForeignKeyViolation
+    };
+    assert_matches!(err, Error::DatabaseError(kind, _) if kind == expected_kind);
+}
+
+#[tokio::test]
+async fn exclusion_violation_error_kind() {
+    let connection = &mut connection().await;
+
+    diesel::sql_query(
+        r#"
+            CREATE TABLE parent (
+                id INTEGER,
+                EXCLUDE USING btree (id WITH =)
+            )
+        "#,
+    )
+    .execute(connection)
+    .await
+    .unwrap();
+
+    insert_into(parent::table)
+        .values(&[Parent { id: 1 }])
+        .execute(connection)
+        .await
+        .unwrap();
+
+    let err = insert_into(parent::table)
+        .values(&[Parent { id: 1 }])
+        .execute(connection)
+        .await
+        .unwrap_err();
+
+    assert_matches!(err, Error::DatabaseError(kind, _) if kind == DatabaseErrorKind::ExclusionViolation);
+}
+
+#[tokio::test]
+async fn not_null_violation_error_kind() {
+    let connection = &mut connection().await;
+    diesel::sql_query(
+        r#"
+            CREATE TABLE users_not_null_name (
+                id INTEGER,
+                name TEXT NOT NULL
+            )
+        "#,
+    )
+    .execute(connection)
+    .await
+    .unwrap();
+
+    let err = diesel::sql_query("INSERT INTO users_not_null_name (id, name) VALUES (0, NULL)")
+        .execute(connection)
+        .await
+        .unwrap_err();
+
+    assert_matches!(err, Error::DatabaseError(kind, _) if kind == DatabaseErrorKind::NotNullViolation);
+}
+
+#[tokio::test]
+async fn check_violation_error_kind() {
+    let connection = &mut connection().await;
+    diesel::sql_query(
+        r#"
+            CREATE TABLE parent (
+                id INTEGER PRIMARY KEY,
+                CHECK ( id = 0 )
+            )
+        "#,
+    )
+    .execute(connection)
+    .await
+    .unwrap();
+
+    let err = insert_into(parent::table)
+        .values(&[Parent { id: 1 }])
+        .execute(connection)
+        .await
+        .unwrap_err();
+    
+    assert_matches!(err, Error::DatabaseError(kind, _) if kind == DatabaseErrorKind::CheckViolation);
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,6 +5,8 @@ use std::fmt::Debug;
 
 #[cfg(feature = "postgres")]
 mod custom_types;
+#[cfg(feature = "postgres")]
+mod errors;
 mod instrumentation;
 #[cfg(feature = "migrations")]
 mod migrations;

--- a/tests/transactions.rs
+++ b/tests/transactions.rs
@@ -228,11 +228,11 @@ async fn commit_with_serialization_failure_already_ends_transaction() {
 #[cfg(feature = "postgres")]
 #[tokio::test]
 async fn read_only_transaction_error_kind() {
+    use assert_matches::assert_matches;
     use diesel::insert_into;
     use diesel::prelude::*;
     use diesel::result::Error;
     use diesel_async::RunQueryDsl;
-    use assert_matches::assert_matches;
 
     table! {
         use diesel::sql_types::*;

--- a/tests/transactions.rs
+++ b/tests/transactions.rs
@@ -224,3 +224,47 @@ async fn commit_with_serialization_failure_already_ends_transaction() {
         res.unwrap_err()
     );
 }
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn read_only_transaction_error_kind() {
+    use diesel::insert_into;
+    use diesel::prelude::*;
+    use diesel::result::Error;
+    use diesel_async::RunQueryDsl;
+    use assert_matches::assert_matches;
+
+    table! {
+        use diesel::sql_types::*;
+        users_read_only {
+            id -> Integer,
+        }
+    }
+
+    #[derive(Insertable, Debug)]
+    #[diesel(table_name = users_read_only)]
+    struct User {
+        id: i32,
+    }
+
+    let mut conn = super::connection_without_transaction().await;
+    diesel::sql_query("CREATE TABLE IF NOT EXISTS users_read_only ( id INTEGER PRIMARY KEY )")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    let mut tx = conn.build_transaction().read_only();
+
+    let err = tx
+        .run(async |c| {
+            insert_into(users_read_only::table)
+                .values(&[User { id: 1 }])
+                .execute(c)
+                .await?;
+            Ok::<_, Error>(())
+        })
+        .await
+        .unwrap_err();
+
+    assert_matches!(err, Error::DatabaseError(kind, _) if kind == diesel::result::DatabaseErrorKind::ReadOnlyTransaction);
+}


### PR DESCRIPTION
I ran into this issue when upgrading from Postgres 17 to Postgres 18:

```
"update or delete on table \"user\" violates RESTRICT setting of foreign key constraint \"sales_order_user_fkey\" on table \"sales_order\"
```

In Postgres 17, when deleting a row with a FK constraint and an `ON DELETE RESTRICT` action a FK violation was triggered (and correctly propagated as such via `diesel::result::DatabaseErrorKind`).

This changed apparently with in v18 where a `RESTRICT VIOLATION` is thrown in such cases. This `SqlState`  wasn't mapped yet in `from_tokio_postgres_error` and therefore fell through to `Unknown`.

I also added `EXCLUSION_VIOLATION` for consistency.

