### PR TITLE
Use get_result instead of execute for pool connection ping

### DIFF
--- a/src/async_connection_wrapper.rs
+++ b/src/async_connection_wrapper.rs
@@ -315,8 +315,8 @@ pub(crate) mod implementation {
         C: crate::AsyncConnection<Backend = <Self as diesel::Connection>::Backend>
             + crate::pooled_connection::PoolableConnection
             + 'static,
-        diesel::dsl::select<diesel::dsl::AsExprOf<i32, diesel::sql_types::Integer>>:
-            crate::methods::ExecuteDsl<C>,
+        for<'a> diesel::dsl::select<diesel::dsl::AsExprOf<i32, diesel::sql_types::Integer>>:
+            crate::methods::LoadQuery<'a, C, i32>,
         diesel::query_builder::SqlQuery: crate::methods::ExecuteDsl<C>,
     {
         fn ping(&mut self) -> diesel::QueryResult<()> {

--- a/src/pooled_connection/bb8.rs
+++ b/src/pooled_connection/bb8.rs
@@ -67,8 +67,8 @@ pub type RunError = bb8::RunError<super::PoolError>;
 impl<C> ManageConnection for AsyncDieselConnectionManager<C>
 where
     C: PoolableConnection + 'static,
-    diesel::dsl::select<diesel::dsl::AsExprOf<i32, diesel::sql_types::Integer>>:
-        crate::methods::ExecuteDsl<C>,
+    for<'a> diesel::dsl::select<diesel::dsl::AsExprOf<i32, diesel::sql_types::Integer>>:
+        crate::methods::LoadQuery<'a, C, i32>,
     diesel::query_builder::SqlQuery: QueryFragment<C::Backend>,
 {
     type Connection = C;

--- a/src/pooled_connection/deadpool.rs
+++ b/src/pooled_connection/deadpool.rs
@@ -74,8 +74,8 @@ pub type HookError = deadpool::managed::HookError<super::PoolError>;
 impl<C> Manager for AsyncDieselConnectionManager<C>
 where
     C: PoolableConnection + Send + 'static,
-    diesel::dsl::select<diesel::dsl::AsExprOf<i32, diesel::sql_types::Integer>>:
-        crate::methods::ExecuteDsl<C>,
+    for<'a> diesel::dsl::select<diesel::dsl::AsExprOf<i32, diesel::sql_types::Integer>>:
+        crate::methods::LoadQuery<'a, C, i32>,
     diesel::query_builder::SqlQuery: QueryFragment<C::Backend>,
 {
     type Type = C;

--- a/src/pooled_connection/mobc.rs
+++ b/src/pooled_connection/mobc.rs
@@ -70,8 +70,8 @@ pub type Builder<C> = mobc::Builder<AsyncDieselConnectionManager<C>>;
 impl<C> Manager for AsyncDieselConnectionManager<C>
 where
     C: PoolableConnection + 'static,
-    diesel::dsl::select<diesel::dsl::AsExprOf<i32, diesel::sql_types::Integer>>:
-        crate::methods::ExecuteDsl<C>,
+    for<'a> diesel::dsl::select<diesel::dsl::AsExprOf<i32, diesel::sql_types::Integer>>:
+        crate::methods::LoadQuery<'a, C, i32>,
     diesel::query_builder::SqlQuery: QueryFragment<C::Backend>,
 {
     type Connection = C;

--- a/src/pooled_connection/mod.rs
+++ b/src/pooled_connection/mod.rs
@@ -173,8 +173,8 @@ pub trait PoolableConnection: AsyncConnection {
     ) -> impl Future<Output = diesel::QueryResult<()>> + Send
     where
         for<'a> Self: 'a,
-        diesel::dsl::select<diesel::dsl::AsExprOf<i32, diesel::sql_types::Integer>>:
-            crate::methods::ExecuteDsl<Self>,
+        for<'a> diesel::dsl::select<diesel::dsl::AsExprOf<i32, diesel::sql_types::Integer>>:
+            crate::methods::LoadQuery<'a, Self, i32>,
         diesel::query_builder::SqlQuery: crate::methods::ExecuteDsl<Self>,
     {
         use crate::run_query_dsl::RunQueryDsl;
@@ -185,7 +185,7 @@ pub trait PoolableConnection: AsyncConnection {
                 RecyclingMethod::Fast => Ok(()),
                 RecyclingMethod::Verified => {
                     diesel::select(1_i32.into_sql::<diesel::sql_types::Integer>())
-                        .execute(self)
+                        .get_result::<i32>(self)
                         .await
                         .map(|_| ())
                 }


### PR DESCRIPTION
## Summary

- Changes the `Verified` recycling method's ping from `.execute()` to `.get_result::<i32>()` so the response row is actually read back from the server
- This detects connections with corrupt internal read buffers that silently pass `.execute()` (which only reads the row count) but fail on real queries with "Unexpected end of row" / "buf doesn't have enough data" errors
- Updates the corresponding trait bounds from `ExecuteDsl` to `LoadQuery` across all pool backends (bb8, deadpool, mobc) and the r2d2 connection wrapper

Fixes #139

## Context

As discussed in #139, the current ping uses `.execute("SELECT 1")` which sends the query and reads the affected row count, but never reads actual row data. A connection whose read buffer contains leftover bytes from a previous partially-consumed response will pass this check, get returned to the pool, and then fail on the next real query.

Using `.get_result::<i32>()` forces the connection to deserialize a row, which will surface buffer corruption immediately during the health check rather than on a subsequent application query.

## Test plan

- [x] `cargo check --features "postgres bb8 deadpool mobc r2d2"` — compiles cleanly
- [x] `cargo check --features "mysql bb8 deadpool mobc"` — compiles cleanly
- [x] `cargo check --features "sqlite bb8 deadpool mobc r2d2"` — compiles cleanly